### PR TITLE
Refactor login route to reuse shared validation utilities

### DIFF
--- a/backend/src/routes/_shared/validation.ts
+++ b/backend/src/routes/_shared/validation.ts
@@ -1,3 +1,18 @@
+import type { FastifyReply } from 'fastify';
 import { z } from 'zod';
+import { errorResponse } from '../../util/errorMessages.js';
 
 export const userIdParams = z.object({ id: z.string().regex(/^\d+$/) });
+
+export function parseBody<S extends z.ZodTypeAny>(
+  schema: S,
+  body: unknown,
+  reply: FastifyReply,
+): z.infer<S> | undefined {
+  const result = schema.safeParse(body);
+  if (!result.success) {
+    reply.code(400).send(errorResponse('invalid request body'));
+    return undefined;
+  }
+  return result.data;
+}

--- a/backend/src/routes/login.ts
+++ b/backend/src/routes/login.ts
@@ -1,23 +1,38 @@
-import type { FastifyInstance, FastifyReply } from 'fastify';
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { OAuth2Client } from 'google-auth-library';
-import { z } from 'zod';
+import jwt from 'jsonwebtoken';
 import { authenticator } from 'otplib';
-import { env } from '../util/env.js';
+import { z } from 'zod';
+
 import { RATE_LIMITS } from '../rate-limit.js';
-import { insertUser, setUserEmail, getUserAuthInfo } from '../repos/users.js';
 import {
   findUserByIdentity,
   insertUserIdentity,
 } from '../repos/user-identities.js';
-import { encrypt } from '../util/crypto.js';
-import { errorResponse, type ErrorResponse } from '../util/errorMessages.js';
-import jwt from 'jsonwebtoken';
+import type { UserIdentityDetails } from '../repos/user-identities.types.js';
+import { getUserAuthInfo, insertUser, setUserEmail } from '../repos/users.js';
 import { requireUserId } from '../util/auth.js';
+import { encrypt } from '../util/crypto.js';
+import { env } from '../util/env.js';
+import { errorResponse, type ErrorResponse } from '../util/errorMessages.js';
+import { parseBody } from './_shared/validation.js';
+
+interface LoginBody {
+  token: string;
+  otp?: string;
+}
 
 interface ValidationErr {
   code: number;
   body: ErrorResponse;
 }
+
+const loginBodySchema: z.ZodType<LoginBody> = z
+  .object({
+    token: z.string(),
+    otp: z.string().optional(),
+  })
+  .strict();
 
 const client = new OAuth2Client();
 
@@ -39,7 +54,62 @@ function setSessionCookie(reply: FastifyReply, id: string) {
   });
 }
 
+function validateOtp(
+  identity: Pick<UserIdentityDetails, 'totpSecret' | 'isTotpEnabled'>,
+  otp: string | undefined,
+): ValidationErr | null {
+  if (identity.isTotpEnabled && identity.totpSecret) {
+    if (!otp) return { code: 401, body: errorResponse('otp required') };
+    const valid = authenticator.verify({
+      token: otp,
+      secret: identity.totpSecret,
+    });
+    if (!valid) return { code: 401, body: errorResponse('invalid otp') };
+  }
+  return null;
+}
+
+function isSameSiteRequest(req: FastifyRequest): boolean {
+  const site = req.headers['sec-fetch-site'];
+  if (site === 'same-origin' || site === 'same-site') return true;
+
+  const origin = req.headers.origin;
+  if (!origin) return false;
+
+  try {
+    const { host } = new URL(origin);
+    return host === req.headers.host;
+  } catch {
+    return false;
+  }
+}
+
+async function runCsrfProtection(
+  app: FastifyInstance,
+  req: FastifyRequest,
+  reply: FastifyReply,
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    (app.csrfProtection as any)(req, reply, (err: any) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+function createCsrfProtectionHandler(app: FastifyInstance) {
+  return async (req: FastifyRequest, reply: FastifyReply) => {
+    if (isSameSiteRequest(req)) return;
+    await runCsrfProtection(app, req, reply);
+  };
+}
+
 export default async function loginRoutes(app: FastifyInstance) {
+  const csrfProtection = createCsrfProtectionHandler(app);
+
   app.get('/login/csrf', async (_req, reply) => ({
     csrfToken: await reply.generateCsrf(),
   }));
@@ -48,51 +118,39 @@ export default async function loginRoutes(app: FastifyInstance) {
     '/login',
     {
       config: { rateLimit: RATE_LIMITS.VERY_TIGHT },
-      onRequest: async (req, reply) => {
-        const site = req.headers['sec-fetch-site'] as string | undefined;
-        if (site === 'same-origin' || site === 'same-site') return;
-        const origin = req.headers.origin;
-        if (origin) {
-          try {
-            const { host } = new URL(origin);
-            if (host === req.headers.host) return;
-          } catch {}
-        }
-        await new Promise<void>((resolve, reject) => {
-          (app.csrfProtection as any)(req, reply, (err: any) =>
-            err ? reject(err) : resolve(),
-          );
-        });
-      },
+      onRequest: csrfProtection,
     },
     async (req, reply) => {
-      const body = z
-        .object({ token: z.string(), otp: z.string().optional() })
-        .parse(req.body);
+      const body = parseBody(loginBodySchema, req.body, reply);
+      if (!body) return;
+
       const payload = await verifyToken(body.token);
       if (!payload?.sub)
         return reply.code(400).send(errorResponse('invalid token'));
+
       const emailEnc = payload.email
         ? encrypt(payload.email, env.KEY_PASSWORD)
         : null;
-      const row = await findUserByIdentity('google', payload.sub);
-      let id: string;
-      if (!row) {
-        id = await insertUser(emailEnc);
+
+      const identity = await findUserByIdentity('google', payload.sub);
+      if (!identity) {
+        const id = await insertUser(emailEnc);
         await insertUserIdentity(id, 'google', payload.sub);
         setSessionCookie(reply, id);
         return { id, email: payload.email, role: 'user' };
       }
-      id = row.id;
+
+      const id = identity.id;
       if (emailEnc) await setUserEmail(id, emailEnc);
-      if (!row.isEnabled) {
+      if (!identity.isEnabled)
         return reply.code(403).send(errorResponse('user disabled'));
-      }
-      const err = validateOtp(row, body.otp);
+
+      const err = validateOtp(identity, body.otp);
       if (err) return reply.code(err.code).send(err.body);
+
       setSessionCookie(reply, id);
-      return { id, email: payload.email, role: row.role };
-    }
+      return { id, email: payload.email, role: identity.role };
+    },
   );
 
   app.get(
@@ -101,24 +159,14 @@ export default async function loginRoutes(app: FastifyInstance) {
     async (req, reply) => {
       const id = requireUserId(req, reply);
       if (!id) return;
+
       const info = await getUserAuthInfo(id);
       if (!info)
         return reply.code(404).send(errorResponse('user not found'));
       if (!info.isEnabled)
         return reply.code(403).send(errorResponse('user disabled'));
+
       return { id, email: info.email, role: info.role };
     },
   );
-}
-
-function validateOtp(
-  row: { totpSecret?: string; isTotpEnabled?: boolean },
-  otp: string | undefined,
-): ValidationErr | null {
-  if (row.isTotpEnabled && row.totpSecret) {
-    if (!otp) return { code: 401, body: errorResponse('otp required') };
-    const valid = authenticator.verify({ token: otp, secret: row.totpSecret });
-    if (!valid) return { code: 401, body: errorResponse('invalid otp') };
-  }
-  return null;
 }


### PR DESCRIPTION
## Summary
- add a reusable `parseBody` helper to the shared route validation utilities
- refactor the login routes to rely on shared parsing, structured CSRF handling, and clearer OTP validation helpers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cfbd5d5db4832ca7d48724f73a8b31