### PR TITLE
Refactor 2FA routes with shared validation

### DIFF
--- a/backend/src/routes/_shared/validation.ts
+++ b/backend/src/routes/_shared/validation.ts
@@ -1,3 +1,18 @@
+import type { FastifyReply, FastifyRequest } from 'fastify';
 import { z } from 'zod';
+import { errorResponse } from '../../util/errorMessages.js';
 
 export const userIdParams = z.object({ id: z.string().regex(/^\d+$/) });
+
+export function parseBody<S extends z.ZodTypeAny>(
+  schema: S,
+  req: FastifyRequest,
+  reply: FastifyReply,
+): z.infer<S> | undefined {
+  const result = schema.safeParse(req.body);
+  if (!result.success) {
+    reply.code(400).send(errorResponse('invalid request body'));
+    return undefined;
+  }
+  return result.data;
+}

--- a/backend/src/routes/twofa.ts
+++ b/backend/src/routes/twofa.ts
@@ -1,8 +1,8 @@
-import type { FastifyInstance } from 'fastify';
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { authenticator } from 'otplib';
 import QRCode from 'qrcode';
-import { requireUserId } from '../util/auth.js';
-import { errorResponse } from '../util/errorMessages.js';
+import { z } from 'zod';
+import { parseBody } from './_shared/validation.js';
 import { RATE_LIMITS } from '../rate-limit.js';
 import {
   clearUserTotp,
@@ -10,60 +10,108 @@ import {
   getUserTotpStatus,
   setUserTotpSecret,
 } from '../repos/users.js';
+import { requireUserId } from '../util/auth.js';
+import { errorResponse } from '../util/errorMessages.js';
+
+const OTP_ISSUER = 'FinCobra' as const;
+
+interface EnableTwofaBody {
+  token: string;
+  secret: string;
+}
+
+interface DisableTwofaBody {
+  token: string;
+}
+
+const tokenSchema = z
+  .string()
+  .trim()
+  .regex(/^\d{6}$/);
+
+const enableTwofaBodySchema: z.ZodType<EnableTwofaBody> = z
+  .object({
+    token: tokenSchema,
+    secret: z.string().trim().min(1),
+  })
+  .strict();
+
+const disableTwofaBodySchema: z.ZodType<DisableTwofaBody> = z
+  .object({ token: tokenSchema })
+  .strict();
+
+function getAuthenticatedUserId(
+  req: FastifyRequest,
+  reply: FastifyReply,
+): string | undefined {
+  const userId = requireUserId(req, reply);
+  if (!userId) return undefined;
+  return userId;
+}
+
+function invalidTokenResponse(reply: FastifyReply) {
+  return reply.code(400).send(errorResponse('invalid token'));
+}
 
 export default async function twofaRoutes(app: FastifyInstance) {
   app.get(
     '/2fa/status',
     { config: { rateLimit: RATE_LIMITS.MODERATE } },
     async (req, reply) => {
-      const userId = requireUserId(req, reply);
+      const userId = getAuthenticatedUserId(req, reply);
       if (!userId) return;
-      return { enabled: await getUserTotpStatus(userId) };
-    }
+      const enabled = await getUserTotpStatus(userId);
+      return { enabled };
+    },
   );
 
   app.get(
     '/2fa/setup',
     { config: { rateLimit: RATE_LIMITS.TIGHT } },
     async (req, reply) => {
-      const userId = requireUserId(req, reply);
+      const userId = getAuthenticatedUserId(req, reply);
       if (!userId) return;
       const secret = authenticator.generateSecret();
-      const otpauthUrl = authenticator.keyuri(String(userId), 'FinCobra', secret);
+      const otpauthUrl = authenticator.keyuri(String(userId), OTP_ISSUER, secret);
       const qr = await QRCode.toDataURL(otpauthUrl);
       return { secret, otpauthUrl, qr };
-    }
+    },
   );
 
   app.post(
     '/2fa/enable',
     { config: { rateLimit: RATE_LIMITS.VERY_TIGHT } },
     async (req, reply) => {
-      const userId = requireUserId(req, reply);
+      const userId = getAuthenticatedUserId(req, reply);
       if (!userId) return;
-      const body = req.body as { token: string; secret: string };
-      const valid = authenticator.verify({ token: body.token, secret: body.secret });
-      if (!valid)
-        return reply.code(400).send(errorResponse('invalid token'));
-      await setUserTotpSecret(userId, body.secret);
+      const body = parseBody(enableTwofaBodySchema, req, reply);
+      if (!body) return;
+      const { token, secret } = body;
+      if (!authenticator.verify({ token, secret })) {
+        return invalidTokenResponse(reply);
+      }
+      await setUserTotpSecret(userId, secret);
       return { enabled: true };
-    }
+    },
   );
 
   app.post(
     '/2fa/disable',
     { config: { rateLimit: RATE_LIMITS.VERY_TIGHT } },
     async (req, reply) => {
-      const userId = requireUserId(req, reply);
+      const userId = getAuthenticatedUserId(req, reply);
       if (!userId) return;
-      const body = req.body as { token: string };
+      const body = parseBody(disableTwofaBodySchema, req, reply);
+      if (!body) return;
       const secret = await getUserTotpSecret(userId);
-      if (!secret)
+      if (!secret) {
         return reply.code(400).send(errorResponse('not enabled'));
-      const valid = authenticator.verify({ token: body.token, secret });
-      if (!valid) return reply.code(400).send(errorResponse('invalid token'));
+      }
+      if (!authenticator.verify({ token: body.token, secret })) {
+        return invalidTokenResponse(reply);
+      }
       await clearUserTotp(userId);
       return { enabled: false };
-    }
+    },
   );
 }


### PR DESCRIPTION
## Summary
- refactor the 2FA routes to follow the structured layout used by other routes
- validate request payloads with zod and centralize body parsing in shared helpers
- reuse shared helpers to keep responses consistent across the route handlers

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/fincobra_test npm --prefix backend test`
- `npm --prefix backend run build`


------
https://chatgpt.com/codex/tasks/task_e_68cfbdd4d014832ca504a1ee60411e56