### PR TITLE
Refactor users routes to use shared guards

### DIFF
--- a/backend/src/routes/_shared/guards.ts
+++ b/backend/src/routes/_shared/guards.ts
@@ -38,9 +38,20 @@ export async function requireAdminOwner(
   req.adminUserId = adminId;
 }
 
+export async function requireAdminAccess(
+    req: FastifyRequest,
+    reply: FastifyReply,
+): Promise<void | FastifyReply> {
+  const adminId = await requireAdmin(req, reply);
+  if (!adminId) return reply;
+  req.adminUserId = adminId;
+}
+
 export function getValidatedUserId(req: FastifyRequest): string {
   return req.validatedUserId!;
 }
 
 export const userPreHandlers = [parseUserIdParam, requireUserOwner];
 export const adminPreHandlers = [parseUserIdParam, requireAdminOwner];
+export const adminOnlyPreHandlers = [requireAdminAccess];
+export const adminManagedUserPreHandlers = [parseUserIdParam, requireAdminAccess];

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -1,64 +1,87 @@
-import type { FastifyInstance } from 'fastify';
-import { z } from 'zod';
-import { requireAdmin } from '../util/auth.js';
-import { listUsers, setUserEnabled, getUser } from '../repos/users.js';
+import type { FastifyInstance, FastifyReply } from 'fastify';
 import { RATE_LIMITS } from '../rate-limit.js';
 import { errorResponse } from '../util/errorMessages.js';
 import { decrypt } from '../util/crypto.js';
 import { env } from '../util/env.js';
-import { parseParams } from '../util/validation.js';
+import { getUser, listUsers, setUserEnabled } from '../repos/users.js';
+import type { UserListEntry } from '../repos/users.types.js';
+import {
+  adminManagedUserPreHandlers,
+  adminOnlyPreHandlers,
+  getValidatedUserId,
+} from './_shared/guards.js';
 
-const idParams = z.object({ id: z.string().regex(/^\d+$/) });
+interface AdminUserResponse {
+  id: string;
+  role: string;
+  isEnabled: boolean;
+  email: string | null;
+  createdAt: string;
+  hasAiKey: boolean;
+  hasBinanceKey: boolean;
+}
+
+interface ToggleUserResponse {
+  ok: true;
+}
+
+function mapUserListEntry(entry: UserListEntry): AdminUserResponse {
+  return {
+    id: entry.id,
+    role: entry.role,
+    isEnabled: entry.isEnabled,
+    email: entry.emailEnc ? decrypt(entry.emailEnc, env.KEY_PASSWORD) : null,
+    createdAt: entry.createdAt,
+    hasAiKey: entry.hasAiKey,
+    hasBinanceKey: entry.hasBinanceKey,
+  };
+}
+
+async function setUserEnabledStatus(
+    reply: FastifyReply,
+    userId: string,
+    enabled: boolean,
+): Promise<ToggleUserResponse | FastifyReply> {
+  const user = await getUser(userId);
+  if (!user) return reply.code(404).send(errorResponse('user not found'));
+  await setUserEnabled(userId, enabled);
+  return { ok: true };
+}
 
 export default async function usersRoutes(app: FastifyInstance) {
   app.get(
     '/users',
-    { config: { rateLimit: RATE_LIMITS.TIGHT } },
-    async (req, reply) => {
-      const adminId = await requireAdmin(req, reply);
-      if (!adminId) return;
+    {
+      config: { rateLimit: RATE_LIMITS.TIGHT },
+      preHandler: adminOnlyPreHandlers,
+    },
+    async () => {
       const rows = await listUsers();
-      return rows.map((u) => ({
-        id: u.id,
-        role: u.role,
-        isEnabled: u.isEnabled,
-        email: u.emailEnc ? decrypt(u.emailEnc, env.KEY_PASSWORD) : null,
-        createdAt: u.createdAt,
-        hasAiKey: u.hasAiKey,
-        hasBinanceKey: u.hasBinanceKey,
-      }));
+      return rows.map(mapUserListEntry);
     },
   );
 
   app.post(
     '/users/:id/enable',
-    { config: { rateLimit: RATE_LIMITS.TIGHT } },
+    {
+      config: { rateLimit: RATE_LIMITS.TIGHT },
+      preHandler: adminManagedUserPreHandlers,
+    },
     async (req, reply) => {
-      const adminId = await requireAdmin(req, reply);
-      if (!adminId) return;
-      const params = parseParams(idParams, req.params, reply);
-      if (!params) return;
-      const { id } = params;
-      const row = await getUser(id);
-      if (!row) return reply.code(404).send(errorResponse('user not found'));
-      await setUserEnabled(id, true);
-      return { ok: true };
+      const userId = getValidatedUserId(req);
+      return setUserEnabledStatus(reply, userId, true);
     },
   );
 
   app.post(
     '/users/:id/disable',
-    { config: { rateLimit: RATE_LIMITS.TIGHT } },
+    {
+      config: { rateLimit: RATE_LIMITS.TIGHT },
+      preHandler: adminManagedUserPreHandlers,
+    },
     async (req, reply) => {
-      const adminId = await requireAdmin(req, reply);
-      if (!adminId) return;
-      const params = parseParams(idParams, req.params, reply);
-      if (!params) return;
-      const { id } = params;
-      const row = await getUser(id);
-      if (!row) return reply.code(404).send(errorResponse('user not found'));
-      await setUserEnabled(id, false);
-      return { ok: true };
+      const userId = getValidatedUserId(req);
+      return setUserEnabledStatus(reply, userId, false);
     },
   );
 }


### PR DESCRIPTION
## Summary
- add reusable admin access guards for routes that validate user params
- refactor user management routes to share response mapping and guard usage

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cfbdf02f78832c8b8c26f3c4a6b85c