### PR TITLE
Handle Binance balances returned as strings

### DIFF
--- a/frontend/src/lib/parseBalanceAmount.ts
+++ b/frontend/src/lib/parseBalanceAmount.ts
@@ -1,0 +1,10 @@
+export function parseBalanceAmount(value: unknown): number {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : 0;
+  }
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return 0;
+}

--- a/frontend/src/lib/useWorkflowBalanceUsd.ts
+++ b/frontend/src/lib/useWorkflowBalanceUsd.ts
@@ -1,7 +1,13 @@
 import axios from 'axios';
 import { useQueries, useQuery } from '@tanstack/react-query';
 import api from './axios';
+import { parseBalanceAmount } from './parseBalanceAmount';
 import { useUser } from './useUser';
+
+interface BinanceBalanceResponse {
+  free?: unknown;
+  locked?: unknown;
+}
 
 export function useWorkflowBalanceUsd(tokens: string[]) {
   const { user } = useUser();
@@ -32,8 +38,9 @@ export function useWorkflowBalanceUsd(tokens: string[]) {
             const res = await api.get(
               `/users/${user!.id}/binance-balance/${token.toUpperCase()}`
             );
-            const bal = res.data as { free: number; locked: number };
-            const amount = (bal.free ?? 0) + (bal.locked ?? 0);
+            const bal = res.data as BinanceBalanceResponse;
+            const amount =
+              parseBalanceAmount(bal.free) + parseBalanceAmount(bal.locked);
             if (!amount) return 0;
             if (['USDT', 'USDC'].includes(token.toUpperCase())) return amount;
             const priceRes = await fetch(


### PR DESCRIPTION
## Summary
- parse Binance account balances returned as strings into numbers
- reuse parsing when loading per-token balance USD calculations
- add a shared helper for converting balance values to numbers safely

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cfdca03824832cb9800ccc5e0ffff8