### PR TITLE
Move shared backend types into dedicated .types modules

### DIFF
--- a/backend/src/agents/main-trader.ts
+++ b/backend/src/agents/main-trader.ts
@@ -14,7 +14,11 @@ import type {
   RebalancePosition,
   PreviousReport,
   RebalancePrompt,
+  MainTraderDecision,
+  MainTraderOrder,
 } from './main-trader.types.js';
+
+export type { MainTraderDecision, MainTraderOrder } from './main-trader.types.js';
 
 export const developerInstructions = [
   '- You are a day-trading portfolio manager who sets target allocations autonomously, trimming highs and buying dips.',
@@ -202,21 +206,6 @@ export async function collectPromptData(
     prompt.previousReports = previousReports;
   }
   return prompt;
-}
-
-export interface MainTraderOrder {
-  pair: string;
-  token: string;
-  side: string;
-  quantity: number;
-  limitPrice: number;
-  basePrice: number;
-  maxPriceDivergencePct: number;
-}
-
-export interface MainTraderDecision {
-  orders: MainTraderOrder[];
-  shortReport: string;
 }
 
 function extractResult(res: string): MainTraderDecision | null {

--- a/backend/src/agents/main-trader.types.ts
+++ b/backend/src/agents/main-trader.types.ts
@@ -73,3 +73,18 @@ export interface RebalancePrompt {
   previousReports?: PreviousReport[];
   reports?: PromptReport[];
 }
+
+export interface MainTraderOrder {
+  pair: string;
+  token: string;
+  side: string;
+  quantity: number;
+  limitPrice: number;
+  basePrice: number;
+  maxPriceDivergencePct: number;
+}
+
+export interface MainTraderDecision {
+  orders: MainTraderOrder[];
+  shortReport: string;
+}

--- a/backend/src/routes/ai-api-keys.ts
+++ b/backend/src/routes/ai-api-keys.ts
@@ -15,10 +15,8 @@ import { verifyAiKey } from '../services/openai-client.js';
 import { encryptKey } from '../util/crypto.js';
 import { errorResponse, ERROR_MESSAGES } from '../util/error-messages.js';
 import { findUserByEmail } from '../repos/users.js';
-import {
-  disableUserWorkflowsByAiKey,
-  type DisableWorkflowsSummary,
-} from '../workflows/disable.js';
+import { disableUserWorkflowsByAiKey } from '../workflows/disable.js';
+import type { DisableWorkflowsSummary } from '../workflows/disable.types.js';
 import {
   adminPreHandlers,
   getValidatedUserId,

--- a/backend/src/routes/exchange-api-keys.ts
+++ b/backend/src/routes/exchange-api-keys.ts
@@ -14,10 +14,8 @@ import { encryptKey } from '../util/crypto.js';
 import { errorResponse, ERROR_MESSAGES } from '../util/error-messages.js';
 import { REDACTED_KEY } from './_shared/constants.js';
 import { getValidatedUserId, userPreHandlers } from './_shared/guards.js';
-import {
-  disableUserWorkflowsByExchangeKey,
-  type DisableWorkflowsSummary,
-} from '../workflows/disable.js';
+import { disableUserWorkflowsByExchangeKey } from '../workflows/disable.js';
+import type { DisableWorkflowsSummary } from '../workflows/disable.types.js';
 import {parseBody} from "./_shared/validation.js";
 
 interface ExchangeKeyBody {

--- a/backend/src/routes/portfolio-workflows.ts
+++ b/backend/src/routes/portfolio-workflows.ts
@@ -37,9 +37,17 @@ import {
   cancelOrdersForWorkflow,
 } from '../services/order-orchestrator.js';
 import { parseBinanceError } from '../services/binance-client.js';
-import type { MainTraderDecision, MainTraderOrder } from '../agents/main-trader.js';
+import type {
+  MainTraderDecision,
+  MainTraderOrder,
+} from '../agents/main-trader.types.js';
 import { getValidatedUserId } from './_shared/guards.js';
 import { parseBody, parseRequestParams } from './_shared/validation.js';
+
+export type {
+  PortfolioWorkflowInput,
+  PortfolioWorkflowTokenInput,
+} from './portfolio-workflows.types.js';
 
 const idParams = z.object({ id: z.string().regex(/^\d+$/) });
 const logIdParams = z.object({ logId: z.string().regex(/^\d+$/) });
@@ -64,8 +72,6 @@ const workflowUpsertSchema = z
     status: z.nativeEnum(PortfolioWorkflowStatus),
   })
   .strip();
-
-export type PortfolioWorkflowInput = z.infer<typeof workflowUpsertSchema>;
 
 const paginationQuerySchema = z.object({
   page: z.string().regex(/^\d+$/).optional(),

--- a/backend/src/routes/portfolio-workflows.types.ts
+++ b/backend/src/routes/portfolio-workflows.types.ts
@@ -1,0 +1,17 @@
+export interface PortfolioWorkflowTokenInput {
+  token: string;
+  minAllocation: number;
+}
+
+export interface PortfolioWorkflowInput {
+  model: string;
+  name: string;
+  cash: string;
+  tokens: PortfolioWorkflowTokenInput[];
+  risk: string;
+  reviewInterval: string;
+  agentInstructions: string;
+  manualRebalance: boolean;
+  useEarn: boolean;
+  status: 'active' | 'inactive' | 'draft' | 'retired';
+}

--- a/backend/src/services/portfolio-workflows.ts
+++ b/backend/src/services/portfolio-workflows.ts
@@ -1,5 +1,8 @@
 import type { FastifyBaseLogger } from 'fastify';
-import type { PortfolioWorkflowInput } from '../routes/portfolio-workflows.js';
+import type {
+  PortfolioWorkflowInput,
+  PortfolioWorkflowTokenInput,
+} from '../routes/portfolio-workflows.types.js';
 import {
   getUserApiKeys,
   findIdenticalDraftWorkflow,
@@ -9,12 +12,7 @@ import { getAiKey, getSharedAiKey } from '../repos/ai-api-key.js';
 import { errorResponse, lengthMessage, type ErrorResponse } from '../util/error-messages.js';
 import { fetchTokensBalanceUsd } from './binance-client.js';
 
-interface TokenAllocation {
-  token: string;
-  minAllocation: number;
-}
-
-function validateAllocations(tokens: TokenAllocation[]) {
+function validateAllocations(tokens: PortfolioWorkflowTokenInput[]) {
   let total = 0;
   for (const allocation of tokens) {
     if (allocation.minAllocation < 0 || allocation.minAllocation > 95)

--- a/backend/src/services/rebalance.ts
+++ b/backend/src/services/rebalance.ts
@@ -1,7 +1,7 @@
 import type { FastifyBaseLogger } from 'fastify';
 import { insertLimitOrder } from '../repos/limit-orders.js';
 import { LimitOrderStatus } from '../repos/limit-orders.types.js';
-import type { MainTraderOrder } from '../agents/main-trader.js';
+import type { MainTraderOrder } from '../agents/main-trader.types.js';
 import {
   fetchPairInfo,
   fetchSymbolPrice,

--- a/backend/src/util/error-messages.ts
+++ b/backend/src/util/error-messages.ts
@@ -1,3 +1,5 @@
+import type { ErrorResponse } from './error-messages.types.js';
+
 export const ERROR_MESSAGES = {
   forbidden: 'forbidden',
   notFound: 'not found',
@@ -7,10 +9,8 @@ export function lengthMessage(field: string, max: number) {
   return `${field} too long (max ${max})`;
 }
 
-export interface ErrorResponse {
-  error: string;
-}
-
 export function errorResponse(message: string): ErrorResponse {
   return { error: message };
 }
+
+export type { ErrorResponse } from './error-messages.types.js';

--- a/backend/src/util/error-messages.types.ts
+++ b/backend/src/util/error-messages.types.ts
@@ -1,0 +1,3 @@
+export interface ErrorResponse {
+  error: string;
+}

--- a/backend/src/util/parse-exec-log.ts
+++ b/backend/src/util/parse-exec-log.ts
@@ -1,23 +1,11 @@
+import type { ExecOrder, ParsedExecLog } from './parse-exec-log.types.js';
 import { TOKEN_SYMBOLS } from './tokens.js';
 
-export interface ExecOrder {
-  pair: string;
-  token: string;
-  side: string;
-  quantity: number;
-  limitPrice?: number;
-  basePrice?: number;
-  maxPriceDivergencePct?: number;
-}
-
-export interface ParsedExecLog {
-  text: string;
-  response?: {
-    orders: ExecOrder[];
-    shortReport: string;
-  };
-  error?: Record<string, unknown>;
-}
+export type {
+  ExecOrder,
+  ParsedExecLog,
+  ParsedExecLogResponse,
+} from './parse-exec-log.types.js';
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);

--- a/backend/src/util/parse-exec-log.types.ts
+++ b/backend/src/util/parse-exec-log.types.ts
@@ -1,0 +1,20 @@
+export interface ExecOrder {
+  pair: string;
+  token: string;
+  side: string;
+  quantity: number;
+  limitPrice?: number;
+  basePrice?: number;
+  maxPriceDivergencePct?: number;
+}
+
+export interface ParsedExecLogResponse {
+  orders: ExecOrder[];
+  shortReport: string;
+}
+
+export interface ParsedExecLog {
+  text: string;
+  response?: ParsedExecLogResponse;
+  error?: Record<string, unknown>;
+}

--- a/backend/src/util/tokens.ts
+++ b/backend/src/util/tokens.ts
@@ -1,7 +1,4 @@
-export interface TokenTags {
-  symbol: string;
-  tags: string[];
-}
+import type { TokenTags } from './tokens.types.js';
 
 export const TOKENS: TokenTags[] = [
   { symbol: 'BTC', tags: ['btc', 'bitcoin'] },
@@ -25,3 +22,5 @@ export const STABLECOINS = ['USDT', 'USDC', 'DAI', 'BUSD', 'TUSD', 'USDP'] as co
 export function isStablecoin(sym: string): boolean {
   return STABLECOINS.includes(sym.toUpperCase() as any);
 }
+
+export type { TokenTags } from './tokens.types.js';

--- a/backend/src/util/tokens.types.ts
+++ b/backend/src/util/tokens.types.ts
@@ -1,0 +1,4 @@
+export interface TokenTags {
+  symbol: string;
+  tags: string[];
+}

--- a/backend/src/workflows/disable.ts
+++ b/backend/src/workflows/disable.ts
@@ -1,5 +1,6 @@
 import type { FastifyBaseLogger } from 'fastify';
 import type { ActivePortfolioWorkflow } from '../repos/portfolio-workflows.js';
+import type { DisableWorkflowsSummary } from './disable.types.js';
 import {
   getActivePortfolioWorkflowsByUser,
   getActivePortfolioWorkflowsByUserAndAiKey,
@@ -13,10 +14,7 @@ import {
 } from '../services/order-orchestrator.js';
 import { removeWorkflowFromSchedule } from './portfolio-review.js';
 
-export interface DisableWorkflowsSummary {
-  disabledWorkflowIds: string[];
-  unscheduledWorkflowIds: string[];
-}
+export type { DisableWorkflowsSummary } from './disable.types.js';
 
 async function disableWorkflowSet(
   log: FastifyBaseLogger,

--- a/backend/src/workflows/disable.types.ts
+++ b/backend/src/workflows/disable.types.ts
@@ -1,0 +1,4 @@
+export interface DisableWorkflowsSummary {
+  disabledWorkflowIds: string[];
+  unscheduledWorkflowIds: string[];
+}

--- a/backend/src/workflows/portfolio-review.ts
+++ b/backend/src/workflows/portfolio-review.ts
@@ -4,11 +4,8 @@ import {
   getActivePortfolioWorkflowsByInterval,
   type ActivePortfolioWorkflow,
 } from '../repos/portfolio-workflows.js';
-import {
-  run as runMainTrader,
-  collectPromptData,
-  type MainTraderDecision,
-} from '../agents/main-trader.js';
+import { run as runMainTrader, collectPromptData } from '../agents/main-trader.js';
+import type { MainTraderDecision } from '../agents/main-trader.types.js';
 import { runNewsAnalyst } from '../agents/news-analyst.js';
 import { runTechnicalAnalyst } from '../agents/technical-analyst.js';
 import { insertReviewRawLog } from '../repos/review-raw-log.js';


### PR DESCRIPTION
## Summary
- extract shared interfaces from backend feature files into colocated `[feature].types.ts` modules
- update routes, services, and workflows to consume the new type modules and re-export types where needed
- ensure all shared shapes use `interface` declarations and adjust imports to avoid circular dependencies

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d25031ee98832c9c1d8a5f69118207