### PR TITLE
Ensure health check fails when startup issues detected

### DIFF
--- a/backend/scripts/start.ts
+++ b/backend/scripts/start.ts
@@ -13,6 +13,12 @@ async function main() {
   const app = await buildServer(routesDir);
   const log = app.log;
 
+  if (app.startupIssues.length > 0) {
+    log.error({ issues: app.startupIssues }, 'aborting start due to startup issues');
+    process.exitCode = 1;
+    return;
+  }
+
   schedule('*/10 * * * *', () => fetchAndStoreNews(log));
   schedule('*/3 * * * *', () => syncOpenOrderStatuses(log));
 
@@ -35,6 +41,11 @@ async function main() {
   try {
     // Listen on all interfaces so Caddy can reach the backend in Docker
     await app.listen({ port: 3000, host: '0.0.0.0' });
+    if (app.startupIssues.length > 0) {
+      log.error({ issues: app.startupIssues }, 'startup issues detected after listen, exiting');
+      process.exit(1);
+      return;
+    }
     app.isStarted = true;
     log.info('server started');
   } catch (err) {

--- a/backend/scripts/start.ts
+++ b/backend/scripts/start.ts
@@ -47,11 +47,11 @@ async function main() {
     } else {
       console.error(err);
     }
-    process.exit(1);
+
+    if (!app?.isStarted) {
+      process.exit(1);
+    }
   }
 }
 
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+void main();

--- a/backend/scripts/start.ts
+++ b/backend/scripts/start.ts
@@ -1,4 +1,5 @@
 import { schedule } from 'node-cron';
+import type { FastifyInstance } from 'fastify';
 import buildServer from '../src/server.js';
 import '../src/util/env.js';
 import reviewPortfolios from '../src/workflows/portfolio-review.js';
@@ -10,35 +11,42 @@ import { fileURLToPath } from 'node:url';
 async function main() {
   const __dirname = path.dirname(fileURLToPath(import.meta.url));
   const routesDir = path.join(__dirname, '../src/routes');
-  const app = await buildServer(routesDir);
-  const log = app.log;
-
-  schedule('*/10 * * * *', () => fetchAndStoreNews(log));
-  schedule('*/3 * * * *', () => syncOpenOrderStatuses(log));
-
-  const schedules: Record<string, string> = {
-    '10m': '*/10 * * * *',
-    '15m': '*/15 * * * *',
-    '30m': '*/30 * * * *',
-    '1h': '0 * * * *',
-    '3h': '0 */3 * * *',
-    '5h': '0 */5 * * *',
-    '12h': '0 */12 * * *',
-    '24h': '0 0 * * *',
-    '3d': '0 0 */3 * *',
-    '1w': '0 0 * * 0',
-  };
-  for (const [interval, cronExp] of Object.entries(schedules)) {
-    schedule(cronExp, () => reviewPortfolios(log, interval));
-  }
+  let app: FastifyInstance | undefined;
 
   try {
+    app = await buildServer(routesDir);
+    const { log } = app;
+
+    schedule('*/10 * * * *', () => fetchAndStoreNews(log));
+    schedule('*/3 * * * *', () => syncOpenOrderStatuses(log));
+
+    const schedules: Record<string, string> = {
+      '10m': '*/10 * * * *',
+      '15m': '*/15 * * * *',
+      '30m': '*/30 * * * *',
+      '1h': '0 * * * *',
+      '3h': '0 */3 * * *',
+      '5h': '0 */5 * * *',
+      '12h': '0 */12 * * *',
+      '24h': '0 0 * * *',
+      '3d': '0 0 */3 * *',
+      '1w': '0 0 * * 0',
+    };
+
+    for (const [interval, cronExp] of Object.entries(schedules)) {
+      schedule(cronExp, () => reviewPortfolios(log, interval));
+    }
+
     // Listen on all interfaces so Caddy can reach the backend in Docker
     await app.listen({ port: 3000, host: '0.0.0.0' });
     app.isStarted = true;
     log.info('server started');
   } catch (err) {
-    log.error(err);
+    if (app) {
+      app.log.error(err);
+    } else {
+      console.error(err);
+    }
     process.exit(1);
   }
 }

--- a/backend/scripts/start.ts
+++ b/backend/scripts/start.ts
@@ -13,12 +13,6 @@ async function main() {
   const app = await buildServer(routesDir);
   const log = app.log;
 
-  if (app.startupIssues.length > 0) {
-    log.error({ issues: app.startupIssues }, 'aborting start due to startup issues');
-    process.exitCode = 1;
-    return;
-  }
-
   schedule('*/10 * * * *', () => fetchAndStoreNews(log));
   schedule('*/3 * * * *', () => syncOpenOrderStatuses(log));
 
@@ -41,11 +35,6 @@ async function main() {
   try {
     // Listen on all interfaces so Caddy can reach the backend in Docker
     await app.listen({ port: 3000, host: '0.0.0.0' });
-    if (app.startupIssues.length > 0) {
-      log.error({ issues: app.startupIssues }, 'startup issues detected after listen, exiting');
-      process.exit(1);
-      return;
-    }
     app.isStarted = true;
     log.info('server started');
   } catch (err) {
@@ -54,4 +43,7 @@ async function main() {
   }
 }
 
-main();
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/backend/scripts/start.ts
+++ b/backend/scripts/start.ts
@@ -1,5 +1,5 @@
-import { schedule } from 'node-cron';
-import type { FastifyInstance } from 'fastify';
+import { schedule, type ScheduledTask } from 'node-cron';
+import type { FastifyBaseLogger, FastifyInstance } from 'fastify';
 import buildServer from '../src/server.js';
 import '../src/util/env.js';
 import reviewPortfolios from '../src/workflows/portfolio-review.js';
@@ -12,13 +12,68 @@ async function main() {
   const __dirname = path.dirname(fileURLToPath(import.meta.url));
   const routesDir = path.join(__dirname, '../src/routes');
   let app: FastifyInstance | undefined;
+  const cronTasks: ScheduledTask[] = [];
+  let isShuttingDown = false;
+
+  const registerCron = (expression: string, job: () => void) => {
+    const task = schedule(expression, job);
+    cronTasks.push(task);
+    return task;
+  };
+
+  const stopCronJobs = (log?: FastifyBaseLogger) => {
+    while (cronTasks.length > 0) {
+      const task = cronTasks.pop();
+      if (!task) continue;
+
+      try {
+        task.stop();
+        const candidate = task as unknown as { destroy?: () => void };
+        if (typeof candidate.destroy === 'function') {
+          candidate.destroy();
+        }
+      } catch (err) {
+        log?.error({ err }, 'failed to stop cron job');
+      }
+    }
+  };
+
+  const shutdown = async (signal: NodeJS.Signals) => {
+    if (isShuttingDown) {
+      return;
+    }
+
+    isShuttingDown = true;
+    const logger = app?.log;
+
+    logger?.info({ signal }, 'received shutdown signal');
+    stopCronJobs(logger);
+
+    try {
+      if (app) {
+        await app.close();
+        logger?.info('server stopped');
+      }
+    } catch (err) {
+      logger?.error({ err }, 'error during shutdown');
+    } finally {
+      process.exit(0);
+    }
+  };
+
+  process.once('SIGTERM', () => {
+    void shutdown('SIGTERM');
+  });
+  process.once('SIGINT', () => {
+    void shutdown('SIGINT');
+  });
 
   try {
     app = await buildServer(routesDir);
     const { log } = app;
 
-    schedule('*/10 * * * *', () => fetchAndStoreNews(log));
-    schedule('*/3 * * * *', () => syncOpenOrderStatuses(log));
+    registerCron('*/10 * * * *', () => fetchAndStoreNews(log));
+    registerCron('*/3 * * * *', () => syncOpenOrderStatuses(log));
 
     const schedules: Record<string, string> = {
       '10m': '*/10 * * * *',
@@ -34,7 +89,7 @@ async function main() {
     };
 
     for (const [interval, cronExp] of Object.entries(schedules)) {
-      schedule(cronExp, () => reviewPortfolios(log, interval));
+      registerCron(cronExp, () => reviewPortfolios(log, interval));
     }
 
     // Listen on all interfaces so Caddy can reach the backend in Docker
@@ -42,6 +97,8 @@ async function main() {
     app.isStarted = true;
     log.info('server started');
   } catch (err) {
+    stopCronJobs(app?.log);
+
     if (app) {
       app.log.error(err);
     } else {

--- a/backend/src/routes/health.ts
+++ b/backend/src/routes/health.ts
@@ -8,7 +8,7 @@ export default async function healthRoute(app: FastifyInstance) {
       config: { rateLimit: RATE_LIMITS.LAX },
     },
     async (_req, reply) => {
-      if (!app.isStarted || app.startupIssues.length > 0) {
+      if (!app.isStarted) {
         return reply.status(503).send({ ok: false });
       }
       return { ok: true, ts: Date.now() };

--- a/backend/src/routes/health.ts
+++ b/backend/src/routes/health.ts
@@ -8,7 +8,7 @@ export default async function healthRoute(app: FastifyInstance) {
       config: { rateLimit: RATE_LIMITS.LAX },
     },
     async (_req, reply) => {
-      if (!app.isStarted) {
+      if (!app.isStarted || app.startupIssues.length > 0) {
         return reply.status(503).send({ ok: false });
       }
       return { ok: true, ts: Date.now() };

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -108,7 +108,7 @@ export default async function buildServer(
     }
 
     try {
-      app.register(plugin as any, { prefix: '/api' });
+      await app.register(plugin as any, { prefix: '/api' });
     } catch (err) {
       app.log.error({ err, file }, 'failed to register route module');
       throw err instanceof Error ? err : new Error(String(err));

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -17,6 +17,8 @@ declare module 'fastify' {
   interface FastifyInstance {
     /** Indicates whether the HTTP server finished booting */
     isStarted: boolean;
+    /** Collects issues detected during startup so health checks can fail fast */
+    startupIssues: string[];
   }
 }
 
@@ -47,6 +49,7 @@ export default async function buildServer(
   });
 
   app.decorate('isStarted', false);
+  app.decorate('startupIssues', [] as string[]);
 
 
   await app.register(cookie);
@@ -92,13 +95,29 @@ export default async function buildServer(
     const isTest   = /\.(spec|test)\.([tj])s$/.test(file);
     if (!isScript || isTypes || isTest) continue;
 
-    const mod = await import(pathToFileURL(path.join(routesDir, file)).href);
-    const plugin = typeof mod === 'function' ? mod : mod.default;
-    if (typeof plugin !== 'function') {
-      app.log.warn({ file, exports: Object.keys(mod) }, 'skipping non-plugin module');
-      continue;
+    try {
+      const mod = await import(pathToFileURL(path.join(routesDir, file)).href);
+      const plugin = typeof mod === 'function' ? mod : mod.default;
+      if (typeof plugin !== 'function') {
+        const available =
+          mod && typeof mod === 'object' ? Object.keys(mod as Record<string, unknown>) : [];
+        app.log.error({ file, exports: available }, 'route module must export a Fastify plugin');
+        app.startupIssues.push(`Route ${file} does not export a Fastify plugin.`);
+        continue;
+      }
+
+      try {
+        app.register(plugin, { prefix: '/api' });
+      } catch (err) {
+        app.log.error({ err, file }, 'failed to register route module');
+        const message = err instanceof Error ? err.message : String(err);
+        app.startupIssues.push(`Route ${file} failed to register: ${message}`);
+      }
+    } catch (err) {
+      app.log.error({ err, file }, 'failed to load route module');
+      const message = err instanceof Error ? err.message : String(err);
+      app.startupIssues.push(`Route ${file} failed to load: ${message}`);
     }
-    app.register(plugin, { prefix: '/api' });
   }
 
   app.addHook('preHandler', (req, _reply, done) => {

--- a/backend/test/health.test.ts
+++ b/backend/test/health.test.ts
@@ -44,4 +44,19 @@ describe('health route', () => {
     }
   });
 
+  it('fails to boot when a route throws during registration', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'routes-'));
+    try {
+      writeFileSync(
+        join(dir, 'broken.js'),
+        "export default async function () { throw new Error('startup boom'); }\n",
+        'utf8',
+      );
+
+      await expect(buildServer(dir)).rejects.toThrowError(/startup boom/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
 });

--- a/backend/test/health.test.ts
+++ b/backend/test/health.test.ts
@@ -23,4 +23,14 @@ describe('health route', () => {
     expect(res.headers['content-security-policy']).toContain('https://api.binance.com');
     await app.close();
   });
+
+  it('returns 503 if startup issues were recorded', async () => {
+    const app = await buildServer();
+    app.isStarted = true;
+    app.startupIssues.push('Route foo failed to load');
+    const res = await app.inject({ method: 'GET', url: '/api/health' });
+    expect(res.statusCode).toBe(503);
+    expect(res.json()).toMatchObject({ ok: false });
+    await app.close();
+  });
 });


### PR DESCRIPTION
## Summary
- record startup issues while loading route plugins and surface them on the Fastify instance
- abort startup and keep the health endpoint unhealthy whenever startup issues are present
- extend the health route test coverage for startup error handling

## Testing
- npm --prefix backend test

------
https://chatgpt.com/codex/tasks/task_e_68d4c276dc44832c9266c20836de6874