### PR TITLE
Disable earn feature by default

### DIFF
--- a/backend/src/routes/portfolio-workflows.ts
+++ b/backend/src/routes/portfolio-workflows.ts
@@ -75,7 +75,7 @@ const workflowUpsertSchema = z
     reviewInterval: z.string(),
     agentInstructions: z.string(),
     manualRebalance: z.boolean().optional().default(false),
-    useEarn: z.boolean().optional().default(true),
+    useEarn: z.boolean().optional().default(false),
     status: z.nativeEnum(PortfolioWorkflowStatus),
   })
   .strip();

--- a/backend/src/services/portfolio-workflows.ts
+++ b/backend/src/services/portfolio-workflows.ts
@@ -174,7 +174,7 @@ export async function preparePortfolioWorkflowForUpsert(
 > {
   try {
     body.manualRebalance = !!body.manualRebalance;
-    body.useEarn = body.useEarn !== false;
+    body.useEarn = body.useEarn === true;
     body.tokens = validateAllocations(body.tokens);
   } catch {
     log.error('invalid allocations');

--- a/frontend/src/components/WalletBalances.tsx
+++ b/frontend/src/components/WalletBalances.tsx
@@ -3,6 +3,8 @@ import { useUser } from '../lib/useUser';
 import type { BalanceInfo } from '../lib/usePrerequisites';
 import { useTranslation } from '../lib/i18n';
 
+const SHOW_EARN_FEATURE = false;
+
 interface Props {
   balances: BalanceInfo[];
   hasBinanceKey: boolean;
@@ -26,7 +28,9 @@ export default function WalletBalances({ balances, hasBinanceKey }: Props) {
           <span className="break-all">
             {b.isLoading
               ? t('loading')
-              : `${b.walletBalance.toFixed(5)} (${t('earn')}: ${b.earnBalance.toFixed(5)})`}
+              : SHOW_EARN_FEATURE
+                ? `${b.walletBalance.toFixed(5)} (${t('earn')}: ${b.earnBalance.toFixed(5)})`
+                : b.walletBalance.toFixed(5)}
           </span>
         </p>
       ))}

--- a/frontend/src/components/forms/PortfolioWorkflowFields.tsx
+++ b/frontend/src/components/forms/PortfolioWorkflowFields.tsx
@@ -22,6 +22,8 @@ import Toggle from '../ui/Toggle';
 import SelectInput from './SelectInput';
 import FormField from './FormField';
 
+const SHOW_EARN_FEATURE = false;
+
 interface Props {
   onTokensChange?: (tokens: string[]) => void;
   balances: BalanceInfo[];
@@ -123,6 +125,8 @@ export default function PortfolioWorkflowFields({
     return sum + usd;
   }, 0);
 
+  const summaryGridCols = SHOW_EARN_FEATURE ? 'grid-cols-4' : 'grid-cols-2';
+
   const handleAddToken = () => {
     const available = tokens.filter(
       (t) =>
@@ -152,7 +156,7 @@ export default function PortfolioWorkflowFields({
       <div className="space-y-2 w-fit">
         <div className={`grid ${colTemplate} gap-2 text-md font-bold`}>
           <div className="text-left">Token</div>
-          <div className="text-left">{useEarn ? 'Spot + Earn' : 'Spot'}</div>
+          <div className="text-left">Spot</div>
           <div className="text-left">Min %</div>
           <div />
         </div>
@@ -241,18 +245,24 @@ export default function PortfolioWorkflowFields({
           </button>
         )}
       </div>
-      <div className="grid grid-cols-4 items-center gap-x-4 gap-y-2 mt-2">
+      <div
+        className={`grid ${summaryGridCols} items-center gap-x-4 gap-y-2 mt-2`}
+      >
         <span className="text-left text-md font-bold">Total $:</span>
         <span>{totalUsd.toFixed(2)}</span>
-        <span className="text-left text-md font-bold">
-          {t('use_binance_earn')}
-        </span>
-        <Toggle
-          label=""
-          checked={useEarn}
-          onChange={onUseEarnChange}
-          size="sm"
-        />
+        {SHOW_EARN_FEATURE && (
+          <>
+            <span className="text-left text-md font-bold">
+              {t('use_binance_earn')}
+            </span>
+            <Toggle
+              label=""
+              checked={useEarn}
+              onChange={onUseEarnChange}
+              size="sm"
+            />
+          </>
+        )}
       </div>
       <div className="grid grid-cols-2 gap-2 mt-2">
         <FormField

--- a/frontend/src/routes/PortfolioWorkflowSetup.tsx
+++ b/frontend/src/routes/PortfolioWorkflowSetup.tsx
@@ -46,7 +46,7 @@ export default function PortfolioWorkflowSetup({ workflow }: Props) {
 
   const [model, setModel] = useState(workflow?.model || '');
   const [aiProvider, setAiProvider] = useState('openai');
-  const [useEarn, setUseEarn] = useState(workflow?.useEarn ?? true);
+  const [useEarn, setUseEarn] = useState(workflow?.useEarn ?? false);
   const [tokenSymbols, setTokenSymbols] = useState(
     defaultValues.tokens.map((t) => t.token),
   );


### PR DESCRIPTION
## Summary
- hide the Earn toggle and labels behind a frontend flag so the feature stays dormant without removing the code
- default new portfolio workflows to useEarn=false across the frontend and backend while preserving existing workflow settings

## Testing
- npm --prefix backend test

------
https://chatgpt.com/codex/tasks/task_e_68d8cd62bf58832cae32cd2b3764e9c2