### PR TITLE
Cache Binance token balance account fetches

### DIFF
--- a/backend/src/routes/binance-balance.ts
+++ b/backend/src/routes/binance-balance.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance, FastifyReply } from 'fastify';
 import { RATE_LIMITS } from '../rate-limit.js';
 import {
   fetchAccount,
+  fetchAccountCached,
   fetchTotalBalanceUsd,
 } from '../services/binance-client.js';
 import type { BinanceAccount } from '../services/binance-client.types.js';
@@ -12,12 +13,15 @@ import {
   userTokenParamsSchema,
 } from './_shared/validation.js';
 
+type AccountFetcher = (userId: string) => Promise<BinanceAccount | null>;
+
 async function loadAccount(
   userId: string,
   reply: FastifyReply,
+  fetcher: AccountFetcher = fetchAccount,
 ): Promise<BinanceAccount | undefined> {
   try {
-    const account = await fetchAccount(userId);
+    const account = await fetcher(userId);
     if (!account) {
       reply.code(404).send(errorResponse(ERROR_MESSAGES.notFound));
       return undefined;
@@ -79,14 +83,14 @@ export default async function binanceBalanceRoutes(app: FastifyInstance) {
   app.get(
     '/users/:id/binance-balance/:token',
     {
-      config: { rateLimit: RATE_LIMITS.RELAXED },
+      config: { rateLimit: RATE_LIMITS.LAX },
       preHandler: userPreHandlers,
     },
     async (req, reply) => {
       const userId = getValidatedUserId(req);
       const params = parseRequestParams(userTokenParamsSchema, req, reply);
       if (!params) return;
-      const account = await loadAccount(userId, reply);
+      const account = await loadAccount(userId, reply, fetchAccountCached);
       if (!account) return;
       const symbol = params.token.toUpperCase();
       const balance = account.balances.find((entry) => entry.asset === symbol);


### PR DESCRIPTION
## Summary
- add a 15-second cached fetch helper for Binance account data that reuses in-flight requests
- update the token balance route to use the cached helper and relax its rate limit configuration

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8cf3cd1a4832c993f641f96f58c8a