### PR TITLE
Adjust portfolio dashboard mobile layout

### DIFF
--- a/frontend/src/lib/i18n.tsx
+++ b/frontend/src/lib/i18n.tsx
@@ -48,7 +48,7 @@ const translations: Record<Lang, Record<string, string>> = {
     binance_api_credentials: 'Binance API Credentials',
     binance_balances: 'Binance Balances',
     connect_binance_api: 'Connect your Binance API',
-    my_workflows: 'My Portfolios',
+    my_workflows: 'Portfolios',
     only_active: 'Only Active',
     only_my: 'Only My',
     please_log_in_workflows: 'Please log in to view your portfolios.',
@@ -220,7 +220,7 @@ const translations: Record<Lang, Record<string, string>> = {
     binance_api_credentials: 'Учётные данные Binance API',
     binance_balances: 'Балансы Binance',
     connect_binance_api: 'Подключите ваш Binance API',
-    my_workflows: 'Мои портфолио',
+    my_workflows: 'Портфели',
     only_active: 'Только активные',
     only_my: 'Только мои',
     please_log_in_workflows:

--- a/frontend/src/routes/Dashboard.tsx
+++ b/frontend/src/routes/Dashboard.tsx
@@ -388,7 +388,13 @@ export default function Dashboard() {
                   </Link>
                 )}
               </div>
-              <div className="flex items-center gap-3">
+              <div
+                className={`flex gap-3 ${
+                  isAdmin
+                    ? 'flex-col items-end sm:flex-row sm:items-center'
+                    : 'items-center'
+                }`}
+              >
                 {isAdmin && (
                   <Toggle
                     label={t('only_my')}


### PR DESCRIPTION
## Summary
- update the portfolio dashboard heading to read "Portfolios" in all locales
- stack the admin-only filters vertically on small screens while keeping horizontal layout on larger screens

## Testing
- npm --prefix frontend run lint

------
https://chatgpt.com/codex/tasks/task_e_68de7f26aebc832c9a5ef5dbf3aff5ae