### PR TITLE
Restore trader instruction guidance expectations

### DIFF
--- a/backend/test/call-ai.test.ts
+++ b/backend/test/call-ai.test.ts
@@ -52,8 +52,10 @@ describe('callAi structured output', () => {
     const [, opts] = fetchMock.mock.calls[0];
     const body = JSON.parse(opts.body);
     expect(opts.body).toBe(JSON.stringify(body));
-    expect(body.instructions).toMatch(/- Decide which limit orders to place/i);
-    expect(body.instructions).toMatch(/On error, return \{error:"message"\}/i);
+    expect(body.instructions).toMatch(
+      /You are a day-trading portfolio manager. Autonomously set target allocations/i,
+    );
+    expect(body.instructions).toMatch(/On error, return error message/i);
     expect(typeof body.input).toBe('string');
     const parsed = JSON.parse(body.input);
     expect(parsed.previousReports).toEqual([


### PR DESCRIPTION
## Summary
- revert the added limit-order directive so developer instructions match their previous wording
- update the call-ai structured output test to assert against the existing instruction text

## Testing
- `npm --prefix backend test`


------
https://chatgpt.com/codex/tasks/task_e_68e07ecd9974832cb81e43d6f93568e8