### PR TITLE
Refine portfolio workflow setup display

### DIFF
--- a/frontend/src/components/AgentInstructions.tsx
+++ b/frontend/src/components/AgentInstructions.tsx
@@ -8,15 +8,26 @@ interface Props {
   maxLength?: number;
 }
 
+const PREVIEW_LINE_LIMIT = 5;
+
 export default function AgentInstructions({
   value,
   onChange,
-  maxLength = 1000,
+  maxLength = 2000,
 }: Props) {
   const [editing, setEditing] = useState(false);
   const [local, setLocal] = useState(value);
   useEffect(() => setLocal(value), [value]);
   const t = useTranslation();
+
+  const trimmedValue = value.trimEnd();
+  const valueLines = trimmedValue ? trimmedValue.split(/\r?\n/) : [];
+  const previewLines = valueLines.slice(0, PREVIEW_LINE_LIMIT);
+  const hasMoreLines = valueLines.length > PREVIEW_LINE_LIMIT;
+  const previewText = hasMoreLines
+    ? `${previewLines.join('\n')}${previewLines.length ? '\n' : ''}…`
+    : trimmedValue;
+
   return (
     <div className="mt-4">
       <div className="flex items-center gap-1 mb-2">
@@ -54,7 +65,9 @@ export default function AgentInstructions({
           </div>
         </>
       ) : (
-        <pre className="whitespace-pre-wrap">{value}</pre>
+        <pre className="whitespace-pre-wrap">
+          {previewLines.length || hasMoreLines ? previewText : value}
+        </pre>
       )}
     </div>
   );

--- a/frontend/src/components/forms/PortfolioWorkflowFields.tsx
+++ b/frontend/src/components/forms/PortfolioWorkflowFields.tsx
@@ -248,8 +248,9 @@ export default function PortfolioWorkflowFields({
       <div
         className={`grid ${summaryGridCols} items-center gap-x-4 gap-y-2 mt-2`}
       >
-        <span className="text-left text-md font-bold">Total $:</span>
-        <span>{totalUsd.toFixed(2)}</span>
+        <span className="text-left text-md font-bold">
+          {`Total: $${totalUsd.toFixed(2)}`}
+        </span>
         {SHOW_EARN_FEATURE && (
           <>
             <span className="text-left text-md font-bold">
@@ -264,11 +265,12 @@ export default function PortfolioWorkflowFields({
           </>
         )}
       </div>
-      <div className="grid grid-cols-2 gap-2 mt-2">
+      <div className="grid grid-cols-2 gap-2 mt-2 max-w-md">
         <FormField
           label={t('risk_tolerance')}
           htmlFor="risk"
           labelClassName="block text-md font-bold"
+          className="w-full"
         >
           <Controller
             name="risk"
@@ -287,6 +289,7 @@ export default function PortfolioWorkflowFields({
           label={t('review_interval')}
           htmlFor="reviewInterval"
           labelClassName="block text-md font-bold"
+          className="w-full"
         >
           <Controller
             name="reviewInterval"

--- a/frontend/src/routes/PortfolioWorkflowSetup.tsx
+++ b/frontend/src/routes/PortfolioWorkflowSetup.tsx
@@ -132,9 +132,6 @@ export default function PortfolioWorkflowSetup({ workflow }: Props) {
   return (
     <div className="p-4">
       <h1 className="text-2xl font-bold mb-1">{t('workflow_setup')}</h1>
-      <p className="text-sm text-gray-600 uppercase tracking-wide">
-        {tokenSymbols.map((t) => t.toUpperCase()).join(' / ')}
-      </p>
       <FormProvider {...methods}>
         <div className="max-w-xl">
           <PortfolioWorkflowFields


### PR DESCRIPTION
## Summary
- remove the redundant token list heading from the workflow setup screen
- limit the trading instructions preview to five lines and raise the editing limit to 2000 characters
- tighten layout spacing around the total value and align dropdown widths with the AI controls

## Testing
- npm --prefix frontend run lint

------
https://chatgpt.com/codex/tasks/task_e_68e0875ea1c0832c8ba210052d040706