### PR TITLE
Add responsive logo to header navigation

### DIFF
--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -35,8 +35,13 @@ export default function AppShell() {
   return (
     <div className="h-screen flex flex-col">
       <header className="fixed top-0 left-0 right-0 bg-gray-800 text-white p-4 flex justify-between z-10">
-        <Link to="/" className="font-bold">
-          FinCobra
+        <Link to="/" className="font-bold flex items-center gap-2">
+          <img
+            src="/logo-min.svg"
+            alt="FinCobra"
+            className="h-8 w-8"
+          />
+          <span className="hidden sm:inline">FinCobra</span>
         </Link>
         <div className="flex items-center gap-4">
           <span className="hidden md:inline">


### PR DESCRIPTION
## Summary
- show the FinCobra logo in the header next to the brand label
- hide the text label on small screens so that only the logo is shown

## Testing
- npm --prefix frontend run lint

------
https://chatgpt.com/codex/tasks/task_e_68e09bbee0ac832cab2ca53716121d4e