### PR TITLE
Add iOS add-to-home-screen hint for mobile visitors

### DIFF
--- a/frontend/src/components/AddToHomeScreenHint.tsx
+++ b/frontend/src/components/AddToHomeScreenHint.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useState } from 'react';
+import { Share } from 'lucide-react';
+import { useTranslation } from '../lib/i18n';
+
+interface AddToHomeScreenHintProps {
+  isLoggedIn: boolean;
+}
+
+function isIosDevice(): boolean {
+  if (typeof window === 'undefined' || typeof navigator === 'undefined') {
+    return false;
+  }
+  const { userAgent, platform, maxTouchPoints } = window.navigator;
+  const normalizedUserAgent = userAgent.toLowerCase();
+
+  if (/iphone|ipad|ipod/.test(normalizedUserAgent)) {
+    return true;
+  }
+
+  return platform === 'MacIntel' && Number(maxTouchPoints) > 1;
+}
+
+function isStandaloneMode(): boolean {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+  const matchMediaStandalone =
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(display-mode: standalone)').matches;
+  const navigatorStandalone =
+    (window.navigator as Navigator & { standalone?: boolean }).standalone === true;
+  return Boolean(matchMediaStandalone || navigatorStandalone);
+}
+
+export default function AddToHomeScreenHint({
+  isLoggedIn,
+}: AddToHomeScreenHintProps) {
+  const [isVisible, setIsVisible] = useState(false);
+  const t = useTranslation();
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof navigator === 'undefined') {
+      return;
+    }
+
+    const mediaQuery =
+      typeof window.matchMedia === 'function'
+        ? window.matchMedia('(max-width: 767px)')
+        : undefined;
+    const displayModeQuery =
+      typeof window.matchMedia === 'function'
+        ? window.matchMedia('(display-mode: standalone)')
+        : undefined;
+
+    const updateVisibility = () => {
+      if (isLoggedIn) {
+        setIsVisible(false);
+        return;
+      }
+
+      const isMobile = mediaQuery?.matches ?? window.innerWidth <= 767;
+      setIsVisible(isIosDevice() && isMobile && !isStandaloneMode());
+    };
+
+    updateVisibility();
+
+    const handleChange = () => updateVisibility();
+
+    if (mediaQuery) {
+      if (typeof mediaQuery.addEventListener === 'function') {
+        mediaQuery.addEventListener('change', handleChange);
+      } else if (typeof mediaQuery.addListener === 'function') {
+        mediaQuery.addListener(handleChange);
+      }
+    }
+
+    if (displayModeQuery) {
+      if (typeof displayModeQuery.addEventListener === 'function') {
+        displayModeQuery.addEventListener('change', handleChange);
+      } else if (typeof displayModeQuery.addListener === 'function') {
+        displayModeQuery.addListener(handleChange);
+      }
+    }
+
+    window.addEventListener('resize', handleChange);
+
+    return () => {
+      if (mediaQuery) {
+        if (typeof mediaQuery.removeEventListener === 'function') {
+          mediaQuery.removeEventListener('change', handleChange);
+        } else if (typeof mediaQuery.removeListener === 'function') {
+          mediaQuery.removeListener(handleChange);
+        }
+      }
+
+      if (displayModeQuery) {
+        if (typeof displayModeQuery.removeEventListener === 'function') {
+          displayModeQuery.removeEventListener('change', handleChange);
+        } else if (typeof displayModeQuery.removeListener === 'function') {
+          displayModeQuery.removeListener(handleChange);
+        }
+      }
+
+      window.removeEventListener('resize', handleChange);
+    };
+  }, [isLoggedIn]);
+
+  if (!isVisible) {
+    return null;
+  }
+
+  return (
+    <div className="md:hidden bg-blue-50 border border-blue-100 text-blue-900 rounded-lg p-3 mb-4 flex items-start gap-3">
+      <Share className="w-5 h-5 mt-1 flex-shrink-0" />
+      <div>
+        <p className="font-semibold">{t('ios_add_to_home_screen_title')}</p>
+        <p className="text-sm mt-1">{t('ios_add_to_home_screen_instructions')}</p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -2,6 +2,7 @@ import { Link, Outlet } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import axios from '../../lib/axios';
 import GoogleLoginButton from '../GoogleLoginButton';
+import AddToHomeScreenHint from '../AddToHomeScreenHint';
 import {
   Bot,
   Key,
@@ -115,6 +116,7 @@ export default function AppShell() {
           </button>
         </nav>
         <main className="flex-1 p-3 pt-0 bg-white overflow-y-auto">
+          <AddToHomeScreenHint isLoggedIn={Boolean(user)} />
           <Outlet />
         </main>
       </div>

--- a/frontend/src/lib/i18n.tsx
+++ b/frontend/src/lib/i18n.tsx
@@ -31,6 +31,9 @@ const translations: Record<Lang, Record<string, string>> = {
     language: 'Language',
     please_log_in: 'Please log in.',
     loading: 'Loading...',
+    ios_add_to_home_screen_title: 'Add FinCobra to your Home Screen',
+    ios_add_to_home_screen_instructions:
+      'Tap the share icon in Safari and choose “Add to Home Screen” to launch FinCobra like an app.',
     twofa_enabled: 'Two-factor authentication is enabled.',
     code: 'Code',
     disable: 'Disable',
@@ -204,6 +207,9 @@ const translations: Record<Lang, Record<string, string>> = {
     language: 'Язык',
     please_log_in: 'Пожалуйста, войдите.',
     loading: 'Загрузка...',
+    ios_add_to_home_screen_title: 'Добавьте FinCobra на главный экран',
+    ios_add_to_home_screen_instructions:
+      'Нажмите на иконку «Поделиться» в Safari и выберите «На экран “Домой”», чтобы запускать FinCobra как приложение.',
     twofa_enabled: 'Двухфакторная аутентификация включена.',
     code: 'Код',
     disable: 'Отключить',


### PR DESCRIPTION
## Summary
- show a mobile banner on iOS Safari encouraging users to add FinCobra to the home screen when logged out
- add localized strings for the add-to-home-screen hint and include it in the main layout

## Testing
- npm --prefix frontend run lint

------
https://chatgpt.com/codex/tasks/task_e_68e0a506432c832c99db1430e31f5e7c