### PR TITLE
Add social post ingestion using agent-twitter-client

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12,6 +12,7 @@
         "@fastify/csrf-protection": "6.4.1",
         "@fastify/helmet": "11.1.1",
         "@fastify/rate-limit": "8.1.1",
+        "agent-twitter-client": "0.0.18",
         "dotenv": "16.6.1",
         "fastify": "4.29.1",
         "google-auth-library": "10.3.0",
@@ -809,6 +810,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -893,6 +906,85 @@
         "@otplib/plugin-crypto": "^12.0.1",
         "@otplib/plugin-thirty-two": "^12.0.1"
       }
+    },
+    "node_modules/@roamhq/wrtc": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@roamhq/wrtc/-/wrtc-0.8.0.tgz",
+      "integrity": "sha512-C0V/nqc4/2xzORI5qa4mIeN/8UO3ywN1kInrJ9u6GljFx0D18JMUJEqe8yYHa61RrEeoWN3PKdW++k8TocSx/A==",
+      "license": "BSD-2-Clause",
+      "optionalDependencies": {
+        "@roamhq/wrtc-darwin-arm64": "0.8.0",
+        "@roamhq/wrtc-darwin-x64": "0.8.0",
+        "@roamhq/wrtc-linux-arm64": "0.8.1",
+        "@roamhq/wrtc-linux-x64": "0.8.1",
+        "@roamhq/wrtc-win32-x64": "0.8.0",
+        "domexception": "^4.0.0"
+      }
+    },
+    "node_modules/@roamhq/wrtc-darwin-arm64": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@roamhq/wrtc-darwin-arm64/-/wrtc-darwin-arm64-0.8.0.tgz",
+      "integrity": "sha512-OtV2KWO7zOG3L8TF3KCt9aucynVCD/ww2xeXXgg+FLkya3ca0uzehN8EQJ3BL4tkInksbFJ2ssyu9cehfJ3ZuA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@roamhq/wrtc-darwin-x64": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@roamhq/wrtc-darwin-x64/-/wrtc-darwin-x64-0.8.0.tgz",
+      "integrity": "sha512-VY7Vzt/SDDDCpW//h8GW9bOZrOr8gWXPZVD9473ypl4jyBIoO57yyLbHzd1G0vBUkS6szsHlQCz1WwpI30YL+g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@roamhq/wrtc-linux-arm64": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@roamhq/wrtc-linux-arm64/-/wrtc-linux-arm64-0.8.1.tgz",
+      "integrity": "sha512-FBJLLazlWkGQUXaokC/rTbrUQbb0CNFYry52fZGstufrGLTWu+g4HcwXdVvxh1tnVtVMvkQGk+mlOL52sCxw0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@roamhq/wrtc-linux-x64": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@roamhq/wrtc-linux-x64/-/wrtc-linux-x64-0.8.1.tgz",
+      "integrity": "sha512-I9oWG7b4uvWO1IOR/aF34n+ID6TKVuSs0jd19h5KdhfRtw7FFh9xxuwN9rONPxLVa6fS0q+MCZgAf8Scz89L8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@roamhq/wrtc-win32-x64": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@roamhq/wrtc-win32-x64/-/wrtc-win32-x64-0.8.0.tgz",
+      "integrity": "sha512-R2fxl41BLWPiP4eaTHGLzbbVvRjx1mV/OsgINCvawO7Hwz5Zx9I45+Fhrw3hd4n5amIeSG9VIF7Kz8eeTFXTGQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.50.0",
@@ -1187,6 +1279,12 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.32.35",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.32.35.tgz",
+      "integrity": "sha512-Ul3YyOTU++to8cgNkttakC0dWvpERr6RYoHO2W47DLbFvrwBDJUY31B1sImH6JZSYc4Kt4PyHtoPNu+vL2r2dA==",
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.2",
@@ -1752,6 +1850,27 @@
         "node": ">= 14"
       }
     },
+    "node_modules/agent-twitter-client": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/agent-twitter-client/-/agent-twitter-client-0.0.18.tgz",
+      "integrity": "sha512-HncH5mlFcGYLEl5wNEkwtdolcmdxqEMIsqO4kTqiTp5P19O25Zr4P6LNJZz1UTjPRyXDxj+BLmmk/Ou7O0QzEg==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
+      "dependencies": {
+        "@roamhq/wrtc": "^0.8.0",
+        "@sinclair/typebox": "^0.32.20",
+        "headers-polyfill": "^3.1.2",
+        "json-stable-stringify": "^1.0.2",
+        "node-fetch": "^3.3.2",
+        "otpauth": "^9.2.2",
+        "set-cookie-parser": "^2.6.0",
+        "tough-cookie": "^4.1.2",
+        "tslib": "^2.5.2",
+        "twitter-api-v2": "^1.18.2",
+        "undici": "^7.1.1",
+        "ws": "^8.18.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
@@ -1961,6 +2080,53 @@
         "node": ">=8"
       }
     },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2160,11 +2326,42 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/dijkstrajs": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
       "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
       "license": "MIT"
+    },
+    "node_modules/domexception": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
+      "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/dotenv": {
       "version": "16.6.1",
@@ -2176,6 +2373,20 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/ecdsa-sig-formatter": {
@@ -2208,12 +2419,42 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.25.9",
@@ -2960,6 +3201,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gaxios": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.1.tgz",
@@ -2995,6 +3245,43 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/glob-parent": {
@@ -3050,6 +3337,18 @@
         "node": ">=14"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -3079,6 +3378,48 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/headers-polyfill": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-3.3.0.tgz",
+      "integrity": "sha512-5e57etwBpNcDc0b6KCVWEh/Ro063OxPvzVimUdM0/tsYM/T7Hfy3kknIGj78SFTOhNd8AZY41U8mOHoO4LzmIQ==",
+      "license": "MIT"
     },
     "node_modules/helmet": {
       "version": "7.2.0",
@@ -3210,6 +3551,12 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -3268,12 +3615,40 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/jsonwebtoken": {
       "version": "9.0.2",
@@ -3458,6 +3833,15 @@
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -3602,6 +3986,15 @@
         "url": "https://opencollective.com/node-fetch"
       }
     },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/obuf": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
@@ -3634,6 +4027,18 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/otpauth": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/otpauth/-/otpauth-9.4.1.tgz",
+      "integrity": "sha512-+iVvys36CFsyXEqfNftQm1II7SW23W1wx9RwNk0Cd97lbvorqAhBDksb/0bYry087QMxjiuBS0wokdoZ0iUeAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "funding": {
+        "url": "https://github.com/hectorm/otpauth?sponsor=1"
       }
     },
     "node_modules/otplib": {
@@ -4045,11 +4450,22 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4072,6 +4488,12 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -4148,6 +4570,12 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "license": "ISC"
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -4332,6 +4760,23 @@
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
       "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
       "license": "MIT"
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -4588,6 +5033,21 @@
         "node": ">=12"
       }
     },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -4600,6 +5060,18 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/twitter-api-v2": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/twitter-api-v2/-/twitter-api-v2-1.27.0.tgz",
+      "integrity": "sha512-hbIFwzg0NeOcFOdmJqtKMCXjLjc0INff/7NwhnZ2zpnw65oku8i+0eMxo5M0iTc1hs+inD/IpDw3S0Xh2c45QQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -4652,12 +5124,30 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
+    "node_modules/undici": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.16.0.tgz",
+      "integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -4667,6 +5157,16 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/uuid": {
@@ -4885,6 +5385,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4946,6 +5456,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xml2js": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,6 +17,7 @@
     "@fastify/csrf-protection": "6.4.1",
     "@fastify/helmet": "11.1.1",
     "@fastify/rate-limit": "8.1.1",
+    "agent-twitter-client": "0.0.18",
     "dotenv": "16.6.1",
     "fastify": "4.29.1",
     "google-auth-library": "10.3.0",

--- a/backend/scripts/start.ts
+++ b/backend/scripts/start.ts
@@ -5,6 +5,7 @@ import '../src/util/env.js';
 import reviewPortfolios from '../src/workflows/portfolio-review.js';
 import { syncOpenOrderStatuses } from '../src/services/order-orchestrator.js';
 import { fetchAndStoreNews } from '../src/services/news.js';
+import { fetchAndStoreSocialPosts } from '../src/services/social.js';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -93,6 +94,7 @@ async function main() {
     const { log } = app;
 
     registerCron('*/10 * * * *', () => fetchAndStoreNews(log));
+    registerCron('*/10 * * * *', () => fetchAndStoreSocialPosts(log));
     registerCron('*/3 * * * *', () => syncOpenOrderStatuses(log));
 
     const schedules: Record<string, string> = {

--- a/backend/src/agents/news-analyst.ts
+++ b/backend/src/agents/news-analyst.ts
@@ -194,7 +194,7 @@ const RULES: Rule[] = [
   {
     id: 'R.W2',
     eventType: 'WhaleMove',
-    regex: /\b(\d[\d,\.]{2,})\s*(btc|eth|sol|usdt|usdc)\b/i,
+    regex: /\b(\d[\d,.]{2,})\s*(btc|eth|sol|usdt|usdc)\b/i,
     basePolarity: 'neutral',
     baseSeverity: 0.45,
     baseConfidence: 0.7,

--- a/backend/src/db/migrations/020_create_social_posts.sql
+++ b/backend/src/db/migrations/020_create_social_posts.sql
@@ -1,0 +1,16 @@
+CREATE TABLE social_posts(
+  id BIGSERIAL PRIMARY KEY,
+  tweet_id TEXT NOT NULL UNIQUE,
+  username TEXT NOT NULL,
+  display_name TEXT,
+  profile_image_url TEXT,
+  text TEXT NOT NULL,
+  permalink TEXT,
+  posted_at TIMESTAMP NOT NULL,
+  tokens TEXT[] NOT NULL,
+  weight REAL NOT NULL,
+  collected_at TIMESTAMP NOT NULL DEFAULT (NOW() AT TIME ZONE 'UTC')
+);
+
+CREATE INDEX idx_social_posts_posted_at ON social_posts(posted_at);
+CREATE INDEX idx_social_posts_tokens ON social_posts USING GIN (tokens);

--- a/backend/src/repos/social-posts.ts
+++ b/backend/src/repos/social-posts.ts
@@ -1,0 +1,61 @@
+import { db } from '../db/index.js';
+import { convertKeysToCamelCase } from '../util/object-case.js';
+import type { SocialPost, SocialPostInsert } from './social-posts.types.js';
+
+export async function insertSocialPosts(items: SocialPostInsert[]): Promise<void> {
+  const filtered = items.filter((item) => item.tokens.length && item.text.trim().length);
+  if (!filtered.length) {
+    return;
+  }
+
+  const params: (string | string[] | number | null)[] = [];
+  const values: string[] = [];
+
+  filtered.forEach((item, index) => {
+    const base = index * 9;
+    values.push(
+      `($${base + 1}, $${base + 2}, $${base + 3}, $${base + 4}, $${base + 5}, $${base + 6}, $${base + 7}, $${base + 8}, $${base + 9})`,
+    );
+    params.push(
+      item.tweetId,
+      item.username,
+      item.displayName ?? null,
+      item.profileImageUrl ?? null,
+      item.text,
+      item.permalink ?? null,
+      item.postedAt,
+      item.tokens,
+      item.weight,
+    );
+  });
+
+  await db.query(
+    `INSERT INTO social_posts (tweet_id, username, display_name, profile_image_url, text, permalink, posted_at, tokens, weight)
+     VALUES ${values.join(', ')}
+     ON CONFLICT (tweet_id) DO UPDATE
+       SET username = EXCLUDED.username,
+           display_name = EXCLUDED.display_name,
+           profile_image_url = EXCLUDED.profile_image_url,
+           text = EXCLUDED.text,
+           permalink = EXCLUDED.permalink,
+           posted_at = EXCLUDED.posted_at,
+           tokens = EXCLUDED.tokens,
+           weight = EXCLUDED.weight`,
+    params,
+  );
+}
+
+export async function getRecentSocialPostsByToken(
+  token: string,
+  limit = 20,
+): Promise<SocialPost[]> {
+  const { rows } = await db.query(
+    `SELECT id, tweet_id, username, display_name, profile_image_url, text, permalink, posted_at, tokens, weight, collected_at
+       FROM social_posts
+      WHERE tokens @> ARRAY[$1]::text[]
+   ORDER BY posted_at DESC
+      LIMIT $2`,
+    [token, limit],
+  );
+  return convertKeysToCamelCase(rows) as SocialPost[];
+}

--- a/backend/src/repos/social-posts.types.ts
+++ b/backend/src/repos/social-posts.types.ts
@@ -1,0 +1,16 @@
+export interface SocialPostInsert {
+  tweetId: string;
+  username: string;
+  displayName?: string | null;
+  profileImageUrl?: string | null;
+  text: string;
+  permalink?: string | null;
+  postedAt: string;
+  tokens: string[];
+  weight: number;
+}
+
+export interface SocialPost extends SocialPostInsert {
+  id: number;
+  collectedAt: string;
+}

--- a/backend/src/services/social.ts
+++ b/backend/src/services/social.ts
@@ -177,6 +177,18 @@ export async function fetchAndStoreSocialPosts(
       } catch (err) {
         perSource[source.username] = 0;
         log.error({ err, source: source.username }, 'failed to fetch tweets for source');
+        scraperInstance = null;
+        scraperPromise = null;
+
+        try {
+          scraper = await getScraper(log);
+          if (!scraper) {
+            break;
+          }
+        } catch (reauthError) {
+          log.error({ err: reauthError }, 'failed to reauthenticate twitter scraper');
+          throw reauthError;
+        }
       }
     }
 

--- a/backend/src/services/social.ts
+++ b/backend/src/services/social.ts
@@ -1,0 +1,202 @@
+import { Scraper } from 'agent-twitter-client';
+import type { Tweet } from 'agent-twitter-client';
+import type { FastifyBaseLogger } from 'fastify';
+import type { SocialSource } from './social.types.js';
+import { env } from '../util/env.js';
+import { insertSocialPosts } from '../repos/social-posts.js';
+import type { SocialPostInsert } from '../repos/social-posts.types.js';
+
+const SOCIAL_SOURCES: SocialSource[] = [
+  { username: 'bitcoin', displayName: 'Bitcoin', tokens: ['BTC'], weight: 0.95 },
+  { username: 'BTC_Archive', displayName: 'BTC Archive', tokens: ['BTC'], weight: 0.75 },
+  { username: 'saylor', displayName: 'Michael Saylor', tokens: ['BTC'], weight: 0.7 },
+  { username: 'cz_binance', displayName: 'CZ 🔶 Binance', tokens: ['BNB'], weight: 0.95 },
+  { username: 'binance', displayName: 'Binance', tokens: ['BNB'], weight: 0.9 },
+  { username: 'BNBCHAIN', displayName: 'BNB Chain', tokens: ['BNB'], weight: 0.85 },
+  { username: 'dogecoin', displayName: 'Dogecoin', tokens: ['DOGE'], weight: 0.9 },
+  { username: 'dogecoinfdn', displayName: 'Dogecoin Foundation', tokens: ['DOGE'], weight: 0.8 },
+  { username: 'BillyM2k', displayName: 'Shibetoshi Nakamoto', tokens: ['DOGE'], weight: 0.7 },
+  { username: 'ethereum', displayName: 'Ethereum', tokens: ['ETH'], weight: 0.95 },
+  { username: 'VitalikButerin', displayName: 'Vitalik Buterin', tokens: ['ETH'], weight: 0.9 },
+  { username: 'Consensys', displayName: 'Consensys', tokens: ['ETH'], weight: 0.75 },
+  { username: 'hedera', displayName: 'Hedera', tokens: ['HBAR'], weight: 0.95 },
+  { username: 'HBAR_foundation', displayName: 'HBAR Foundation', tokens: ['HBAR'], weight: 0.85 },
+  { username: 'SwirldsLabs', displayName: 'Swirlds Labs', tokens: ['HBAR'], weight: 0.75 },
+  { username: 'pepecoineth', displayName: 'Pepe Coin', tokens: ['PEPE'], weight: 0.9 },
+  { username: 'pepecommunity', displayName: 'PEPE Community', tokens: ['PEPE'], weight: 0.75 },
+  { username: 'lordkeklol', displayName: 'Lord Kek', tokens: ['PEPE'], weight: 0.7 },
+  { username: 'Shibtoken', displayName: 'Shib', tokens: ['SHIB'], weight: 0.95 },
+  { username: 'ShibariumNet', displayName: 'Shibarium Network', tokens: ['SHIB'], weight: 0.85 },
+  { username: 'ShibArmy', displayName: 'Shib Army', tokens: ['SHIB'], weight: 0.75 },
+  { username: 'solana', displayName: 'Solana', tokens: ['SOL'], weight: 0.95 },
+  { username: 'SolanaFndn', displayName: 'Solana Foundation', tokens: ['SOL'], weight: 0.85 },
+  { username: 'aeyakovenko', displayName: 'Anatoly Yakovenko', tokens: ['SOL'], weight: 0.75 },
+  { username: 'ton_blockchain', displayName: 'TON 💎', tokens: ['TON'], weight: 0.95 },
+  { username: 'ton_status', displayName: 'TON Status', tokens: ['TON'], weight: 0.8 },
+  { username: 'ton_society', displayName: 'TON Society', tokens: ['TON'], weight: 0.7 },
+  { username: 'trondao', displayName: 'TRON DAO', tokens: ['TRX'], weight: 0.9 },
+  { username: 'justinsuntron', displayName: 'Justin Sun', tokens: ['TRX'], weight: 0.85 },
+  { username: 'tronscan_org', displayName: 'TRONSCAN', tokens: ['TRX'], weight: 0.75 },
+  { username: 'Ripple', displayName: 'Ripple', tokens: ['XRP'], weight: 0.95 },
+  { username: 'XRPLLabs', displayName: 'XRPL Labs', tokens: ['XRP'], weight: 0.8 },
+  { username: 'XRP_community', displayName: 'XRP Community', tokens: ['XRP'], weight: 0.7 },
+  { username: 'Tether_to', displayName: 'Tether', tokens: ['USDT'], weight: 0.95 },
+  { username: 'paoloardoino', displayName: 'Paolo Ardoino', tokens: ['USDT'], weight: 0.85 },
+  { username: 'TetherGoldToken', displayName: 'Tether Gold', tokens: ['USDT'], weight: 0.7 },
+  { username: 'circle', displayName: 'Circle', tokens: ['USDC'], weight: 0.95 },
+  { username: 'centre_io', displayName: 'Centre', tokens: ['USDC'], weight: 0.8 },
+  { username: 'jerallaire', displayName: 'Jeremy Allaire', tokens: ['USDC'], weight: 0.75 },
+];
+
+const SOCIAL_WEIGHTS: Record<string, number> = SOCIAL_SOURCES.reduce(
+  (acc, source) => {
+    acc[source.username.toLowerCase()] = source.weight;
+    return acc;
+  },
+  {} as Record<string, number>,
+);
+
+let scraperPromise: Promise<Scraper> | null = null;
+let scraperInstance: Scraper | null = null;
+
+async function getScraper(log?: FastifyBaseLogger): Promise<Scraper | null> {
+  const username = env.TWITTER_USERNAME;
+  const password = env.TWITTER_PASSWORD;
+  const email = env.TWITTER_EMAIL;
+
+  if (!username || !password) {
+    log?.warn('Twitter credentials are not configured; skipping social sync.');
+    return null;
+  }
+
+  if (scraperInstance) {
+    return scraperInstance;
+  }
+
+  if (!scraperPromise) {
+    scraperPromise = (async () => {
+      const client = new Scraper();
+      if (email) {
+        await client.login(username, password, email);
+      } else {
+        await client.login(username, password);
+      }
+      return client;
+    })();
+  }
+
+  try {
+    scraperInstance = await scraperPromise;
+    return scraperInstance;
+  } catch (err) {
+    scraperPromise = null;
+    scraperInstance = null;
+    log?.error({ err }, 'failed to initialize twitter scraper');
+    throw err;
+  }
+}
+
+function extractPostedAt(tweet: Tweet): string | null {
+  if (tweet.timeParsed instanceof Date && !Number.isNaN(tweet.timeParsed.valueOf())) {
+    return tweet.timeParsed.toISOString();
+  }
+  if (typeof tweet.timestamp === 'number') {
+    const ms = tweet.timestamp * 1000;
+    return new Date(ms).toISOString();
+  }
+  return null;
+}
+
+async function collectTweetsForSource(
+  scraper: Scraper,
+  source: SocialSource,
+): Promise<SocialPostInsert[]> {
+  const posts: SocialPostInsert[] = [];
+  let fetched = 0;
+
+  try {
+    for await (const tweet of scraper.getTweets(source.username, 5)) {
+      if (!tweet || !tweet.id || !tweet.text) {
+        continue;
+      }
+      if (tweet.isRetweet) {
+        continue;
+      }
+
+      const postedAt = extractPostedAt(tweet);
+      if (!postedAt) {
+        continue;
+      }
+
+      const trimmed = tweet.text.trim();
+      if (!trimmed.length) {
+        continue;
+      }
+
+      posts.push({
+        tweetId: tweet.id,
+        username: tweet.username ?? source.username,
+        displayName: tweet.name ?? source.displayName ?? null,
+        profileImageUrl: null,
+        text: trimmed,
+        permalink: tweet.permanentUrl ?? null,
+        postedAt,
+        tokens: source.tokens,
+        weight: source.weight,
+      });
+      fetched++;
+      if (fetched >= 3) {
+        break;
+      }
+    }
+  } catch (err) {
+    throw err;
+  }
+
+  return posts;
+}
+
+export async function fetchAndStoreSocialPosts(
+  log: FastifyBaseLogger,
+): Promise<void> {
+  let scraper: Scraper | null = null;
+  try {
+    scraper = await getScraper(log);
+    if (!scraper) {
+      return;
+    }
+
+    const collected: SocialPostInsert[] = [];
+    const perSource: Record<string, number> = {};
+
+    for (const source of SOCIAL_SOURCES) {
+      try {
+        const posts = await collectTweetsForSource(scraper, source);
+        perSource[source.username] = posts.length;
+        collected.push(...posts);
+      } catch (err) {
+        perSource[source.username] = 0;
+        log.error({ err, source: source.username }, 'failed to fetch tweets for source');
+      }
+    }
+
+    if (collected.length) {
+      await insertSocialPosts(collected);
+    }
+
+    log.info(
+      {
+        totalSources: SOCIAL_SOURCES.length,
+        totalCollected: collected.length,
+        perSource,
+      },
+      'social post fetch summary',
+    );
+  } catch (err) {
+    log.error({ err }, 'failed to fetch or store social posts');
+    scraperInstance = null;
+    scraperPromise = null;
+  }
+}
+
+export { SOCIAL_SOURCES, SOCIAL_WEIGHTS };

--- a/backend/src/services/social.ts
+++ b/backend/src/services/social.ts
@@ -73,6 +73,7 @@ async function getScraper(log?: FastifyBaseLogger): Promise<Scraper | null> {
   const username = env.TWITTER_USERNAME;
   const password = env.TWITTER_PASSWORD;
   const email = env.TWITTER_EMAIL;
+  const twoFactorSecret = env.TWITTER_2FA_SECRET;
 
   if (!username || !password) {
     log?.warn('Twitter credentials are not configured; skipping social sync.');
@@ -93,11 +94,7 @@ async function getScraper(log?: FastifyBaseLogger): Promise<Scraper | null> {
   if (!scraperPromise) {
     const loginTask = (async () => {
       const client = new Scraper();
-      if (email) {
-        await client.login(username, password, email);
-      } else {
-        await client.login(username, password);
-      }
+      await client.login(username, password, email, twoFactorSecret);
       loginFailureCount = 0;
       nextLoginAttemptAt = 0;
       return client;

--- a/backend/src/services/social.types.ts
+++ b/backend/src/services/social.types.ts
@@ -1,0 +1,6 @@
+export interface SocialSource {
+  username: string;
+  displayName?: string;
+  tokens: string[];
+  weight: number;
+}

--- a/backend/src/util/env.ts
+++ b/backend/src/util/env.ts
@@ -10,6 +10,7 @@ const envSchema = z.object({
   TWITTER_USERNAME: z.string().optional(),
   TWITTER_PASSWORD: z.string().optional(),
   TWITTER_EMAIL: z.string().optional(),
+  TWITTER_2FA_SECRET: z.string().optional(),
 });
 
 export const env = envSchema.parse(process.env);

--- a/backend/src/util/env.ts
+++ b/backend/src/util/env.ts
@@ -7,6 +7,9 @@ const envSchema = z.object({
   DATABASE_URL: z.string().default('postgres://localhost:5432/postgres'),
   KEY_PASSWORD: z.string(),
   GOOGLE_CLIENT_ID: z.string(),
+  TWITTER_USERNAME: z.string().optional(),
+  TWITTER_PASSWORD: z.string().optional(),
+  TWITTER_EMAIL: z.string().optional(),
 });
 
 export const env = envSchema.parse(process.env);


### PR DESCRIPTION
## Summary
- add the agent-twitter-client dependency and extend environment parsing for Twitter credentials
- create a social post repository, schema migration, and cron job wiring to store token-tagged tweets
- hardcode weighted token-specific Twitter sources and persist each account’s latest posts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2494156ec832c9e59245b787aff16