### PR TITLE
Update PWA icons to use branded assets

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/logo-min.svg" />
-    <link rel="apple-touch-icon" href="/logo-min.svg" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/logo-180.png" />
     <link rel="manifest" href="/manifest.webmanifest" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black" />

--- a/frontend/public/manifest.webmanifest
+++ b/frontend/public/manifest.webmanifest
@@ -7,7 +7,18 @@
   "theme_color": "#ffffff",
   "icons": [
     {
-      "src": "/vite.svg",
+      "src": "/logo-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/logo-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "/logo-min.svg",
       "sizes": "any",
       "type": "image/svg+xml",
       "purpose": "any maskable"


### PR DESCRIPTION
## Summary
- point the web app manifest at the existing branded logo assets for installable icons
- update the apple touch icon to the 180px PNG so iOS saves the proper app icon

## Testing
- npm --prefix frontend run lint

------
https://chatgpt.com/codex/tasks/task_e_68e33d42e40c832c9f0818fe7ab2f073