### PR TITLE
Require explicit decision intervals for market overview caching

### DIFF
--- a/backend/src/services/indicators.ts
+++ b/backend/src/services/indicators.ts
@@ -10,12 +10,11 @@ import type {
 
 const HOUR_INTERVAL_LIMIT = 1000;
 const HOUR_BASELINE = 24 * 30;
+const LTF_FETCH_BUFFER = 16;
 
-const TIMEFRAME: MarketOverviewPayload['timeframe'] = {
-  candleInterval: '1h',
-  reviewInterval: '30m',
-  semantics:
-    'All base fields are computed on 1h candles for a 30m decision cadence. Higher-timeframe (HTF) context adds 4h/1d/1w trend and 30d/90d/180d/365d returns.',
+const LTF_CONFIG: Record<'10m' | '30m', { interval: '10m' | '30m'; fast: number; slow: number }> = {
+  '10m': { interval: '10m', fast: 12, slow: 48 },
+  '30m': { interval: '30m', fast: 6, slow: 24 },
 };
 
 const DERIVATIONS: MarketOverviewPayload['derivations'] = {
@@ -62,6 +61,10 @@ const SPEC: MarketOverviewPayload['spec'] = {
     'htf.regime.volRank1y': '0–1 (percentile)',
     'htf.regime.corrBtc90d': '[-1,1]',
     'htf.regime.marketBeta90d': 'float',
+    'ltf.ret10m|ret30m': 'decimal',
+    'ltf.rsi10m|rsi30m': '0–100',
+    "ltf.slope10m|slope30m": "enum('up','flat','down')",
+    'ltf.alignmentScore': '[-1,1]',
   },
   interpretation: {
     trendSlope: 'Multi-day trend on 1h timeframe (SMA50 vs SMA200).',
@@ -107,12 +110,34 @@ const btcContextCache = new NodeCache({
 const pendingTokenFetches = new Map<string, Promise<CachedTokenOverview>>();
 let pendingBtcContext: Promise<CachedBtcContext> | null = null;
 
-function buildTokenPendingKey(token: string, contextKey: string): string {
-  return `${token}|${contextKey}`;
+function buildOptionsKey(decisionInterval: string, ltfFrames: readonly string[]): string {
+  return `${decisionInterval}|${ltfFrames.join(',')}`;
 }
 
-function setTokenCache(token: string, value: CachedTokenOverview) {
-  tokenOverviewCache.set<CachedTokenOverview>(token, value);
+function buildTokenCacheKey(token: string, optionsKey: string): string {
+  return `${token}|${optionsKey}`;
+}
+
+function buildTokenPendingKey(cacheKey: string, contextKey: string): string {
+  return `${cacheKey}|${contextKey}`;
+}
+
+function setTokenCache(key: string, value: CachedTokenOverview) {
+  tokenOverviewCache.set<CachedTokenOverview>(key, value);
+}
+
+export function buildTimeframe(
+  decisionInterval: string,
+): MarketOverviewPayload['timeframe'] {
+  if (!decisionInterval) {
+    throw new Error('decision interval is required to build timeframe');
+  }
+  return {
+    candleInterval: '1h',
+    decisionInterval,
+    semantics:
+      'Base fields computed on candleInterval; decisions run every decisionInterval. LTF (optional) derives from requested frames.',
+  };
 }
 
 async function getBtcContext(): Promise<CachedBtcContext> {
@@ -143,9 +168,15 @@ async function getBtcContext(): Promise<CachedBtcContext> {
   return pendingBtcContext!;
 }
 
+interface TokenOverviewOptions {
+  requestedFrames: Array<'10m' | '30m' | '1h'>;
+  computeFrames: Array<'10m' | '30m'>;
+}
+
 async function computeTokenOverview(
   token: string,
   btcContext: CachedBtcContext,
+  options: TokenOverviewOptions,
 ): Promise<CachedTokenOverview> {
   const pair =
     token === 'BTC' ? btcContext.pair : await fetchPairData(token, 'USDT');
@@ -180,6 +211,18 @@ async function computeTokenOverview(
   overview.orderbookDepthRatio = askQty === 0 ? 0 : bidQty / askQty;
   overview.riskFlags = computeRiskFlags(overview);
 
+  if (options.requestedFrames.length) {
+    const ltf = await computeLtfMetrics(
+      symbol,
+      overview,
+      options.requestedFrames,
+      options.computeFrames,
+    );
+    if (ltf) {
+      overview.ltf = ltf;
+    }
+  }
+
   return {
     overview,
     generatedAt: new Date().toISOString(),
@@ -190,19 +233,20 @@ async function computeTokenOverview(
 async function loadTokenOverview(
   token: string,
   btcContext: CachedBtcContext,
+  options: TokenOverviewOptions,
+  tokenCacheKey: string,
 ): Promise<CachedTokenOverview> {
-  const cacheKey = token.toUpperCase();
-  const cached = tokenOverviewCache.get<CachedTokenOverview>(cacheKey);
+  const cached = tokenOverviewCache.get<CachedTokenOverview>(tokenCacheKey);
   if (cached && cached.contextKey === btcContext.cacheKey) {
     return cached;
   }
 
-  const pendingKey = buildTokenPendingKey(cacheKey, btcContext.cacheKey);
+  const pendingKey = buildTokenPendingKey(tokenCacheKey, btcContext.cacheKey);
   let pending = pendingTokenFetches.get(pendingKey);
   if (!pending) {
-    pending = computeTokenOverview(cacheKey, btcContext)
+    pending = computeTokenOverview(token, btcContext, options)
       .then((result) => {
-        setTokenCache(cacheKey, result);
+        setTokenCache(tokenCacheKey, result);
         return result;
       })
       .finally(() => {
@@ -212,18 +256,22 @@ async function loadTokenOverview(
   }
   const result = await pending;
   if (result.contextKey !== btcContext.cacheKey) {
-    return loadTokenOverview(token, btcContext);
+    return loadTokenOverview(token, btcContext, options, tokenCacheKey);
   }
   return result;
 }
 
 export function createEmptyMarketOverview(
   asOf: Date = new Date(),
+  decisionInterval: string,
 ): MarketOverviewPayload {
+  if (!decisionInterval) {
+    throw new Error('decision interval is required to create market overview');
+  }
   return {
-    schema: 'market_overview.v2',
+    schema: 'market_overview.v2.1',
     asOf: asOf.toISOString(),
-    timeframe: TIMEFRAME,
+    timeframe: buildTimeframe(decisionInterval),
     derivations: DERIVATIONS,
     spec: SPEC,
     marketOverview: {},
@@ -523,12 +571,105 @@ function buildTokenOverview(
   return token;
 }
 
+function slopeToScore(
+  slope: MarketOverviewTrendFrame['slope'] | undefined,
+  weight: number,
+): number {
+  if (slope === 'up') return weight;
+  if (slope === 'down') return -weight;
+  return 0;
+}
+
+async function computeLtfMetrics(
+  symbol: string,
+  baseOverview: MarketOverviewToken,
+  requestedFrames: Array<'10m' | '30m' | '1h'>,
+  computeFrames: Array<'10m' | '30m'>,
+): Promise<MarketOverviewToken['ltf'] | null> {
+  if (!requestedFrames.length) {
+    return null;
+  }
+
+  const ltf: MarketOverviewToken['ltf'] = {
+    frames: requestedFrames,
+    alignmentScore: 0,
+  };
+
+  await Promise.all(
+    computeFrames.map(async (frame) => {
+      const config = LTF_CONFIG[frame];
+      const limit = Math.max(config.slow, 14) + LTF_FETCH_BUFFER;
+      const klines = await fetchIntervalKlines(symbol, config.interval, limit);
+      const closes = klines.map((k) => Number(k[4]));
+      const lastClose = closes[closes.length - 1];
+      const retValue =
+        lastClose !== undefined ? calcReturn(closes, 1, lastClose) : 0;
+      const rsiValue = calcRsi(closes);
+      const trend = computeTrendFrame(closes, config.fast, config.slow, [
+        config.fast,
+        config.slow,
+      ]);
+
+      if (frame === '10m') {
+        ltf.ret10m = retValue;
+        ltf.rsi10m = rsiValue;
+        ltf.slope10m = trend.slope;
+      } else if (frame === '30m') {
+        ltf.ret30m = retValue;
+        ltf.rsi30m = rsiValue;
+        ltf.slope30m = trend.slope;
+      }
+    }),
+  );
+
+  const contributions: number[] = [
+    slopeToScore(baseOverview.trendSlope, 1),
+    slopeToScore(baseOverview.htf.trend['4h'].slope, 1),
+  ];
+  if (computeFrames.includes('10m')) {
+    contributions.push(slopeToScore(ltf.slope10m, 0.5));
+  }
+  if (computeFrames.includes('30m')) {
+    contributions.push(slopeToScore(ltf.slope30m, 0.5));
+  }
+  const alignment =
+    contributions.reduce((sum, value) => sum + value, 0) / contributions.length;
+  ltf.alignmentScore = Math.max(-1, Math.min(1, alignment));
+
+  return ltf;
+}
+
 export async function fetchMarketOverview(
   tokens: string[],
+  opts?: {
+    decisionInterval?: string;
+    ltfFrames?: Array<'10m' | '30m' | '1h'>;
+  },
 ): Promise<MarketOverviewPayload> {
-  if (!tokens.length) {
-    return createEmptyMarketOverview();
+  const decisionInterval = opts?.decisionInterval;
+  if (!decisionInterval) {
+    throw new Error('decisionInterval is required when fetching market overview');
   }
+  if (!tokens.length) {
+    return createEmptyMarketOverview(new Date(), decisionInterval);
+  }
+  const frameOrder: Record<'10m' | '30m' | '1h', number> = {
+    '10m': 0,
+    '30m': 1,
+    '1h': 2,
+  };
+  const requestedFrames = Array.from(
+    new Set(
+      (opts?.ltfFrames ?? []).filter(
+        (frame): frame is '10m' | '30m' | '1h' =>
+          frame === '10m' || frame === '30m' || frame === '1h',
+      ),
+    ),
+  ).sort((a, b) => frameOrder[a] - frameOrder[b]);
+  const computeFrames = requestedFrames.filter(
+    (frame): frame is '10m' | '30m' => frame === '10m' || frame === '30m',
+  );
+  const optionsKey = buildOptionsKey(decisionInterval, requestedFrames);
 
   const dedupedSet = new Set(tokens.map((t) => t.toUpperCase()));
   dedupedSet.add('BTC');
@@ -536,7 +677,13 @@ export async function fetchMarketOverview(
   const btcContext = await getBtcContext();
   const entries = await Promise.all(
     deduped.map(async (token) => {
-      const data = await loadTokenOverview(token, btcContext);
+      const tokenKey = buildTokenCacheKey(token.toUpperCase(), optionsKey);
+      const data = await loadTokenOverview(
+        token,
+        btcContext,
+        { requestedFrames, computeFrames },
+        tokenKey,
+      );
       return [token, data] as const;
     }),
   );
@@ -551,10 +698,10 @@ export async function fetchMarketOverview(
   }, new Date(0));
 
   return {
-    schema: 'market_overview.v2',
+    schema: 'market_overview.v2.1',
     asOf:
       latestAsOf.getTime() > 0 ? latestAsOf.toISOString() : new Date().toISOString(),
-    timeframe: TIMEFRAME,
+    timeframe: buildTimeframe(decisionInterval),
     derivations: DERIVATIONS,
     spec: SPEC,
     marketOverview,

--- a/backend/src/services/indicators.types.ts
+++ b/backend/src/services/indicators.types.ts
@@ -40,6 +40,17 @@ export interface MarketOverviewHtf {
   regime: MarketOverviewRegime;
 }
 
+export interface MarketOverviewLtf {
+  frames: Array<'10m' | '30m' | '1h'>;
+  ret10m?: number;
+  ret30m?: number;
+  rsi10m?: number;
+  rsi30m?: number;
+  slope10m?: 'up' | 'flat' | 'down';
+  slope30m?: 'up' | 'flat' | 'down';
+  alignmentScore: number;
+}
+
 export interface MarketOverviewToken {
   trendSlope: 'up' | 'flat' | 'down';
   trendBasis: MarketOverviewTrendBasis;
@@ -52,11 +63,12 @@ export interface MarketOverviewToken {
   orderbookDepthRatio: number;
   riskFlags: MarketOverviewRiskFlags;
   htf: MarketOverviewHtf;
+  ltf?: MarketOverviewLtf;
 }
 
 export interface MarketOverviewTimeframe {
   candleInterval: string;
-  reviewInterval: string;
+  decisionInterval: string;
   semantics: string;
 }
 
@@ -87,7 +99,7 @@ export interface MarketOverviewSpec {
 }
 
 export interface MarketOverviewPayload {
-  schema: 'market_overview.v2';
+  schema: 'market_overview.v2.1';
   asOf: string;
   timeframe: MarketOverviewTimeframe;
   derivations: MarketOverviewDerivations;

--- a/backend/test/collect-prompt-data.test.ts
+++ b/backend/test/collect-prompt-data.test.ts
@@ -144,7 +144,7 @@ describe('collectPromptData', () => {
     expect(prompt?.portfolio.startBalanceUsd).toBe(20000);
     expect(prompt?.portfolio.startBalanceTs).toBe('2025-01-01T00:00:00.000Z');
     expect(prompt?.portfolio.pnlUsd).toBeCloseTo(1000);
-    expect(prompt?.reviewInterval).toBe('1h');
+    expect(prompt?.reviewInterval).toBe('PT1H');
     expect(prompt).not.toHaveProperty('instructions');
   });
 
@@ -317,6 +317,30 @@ describe('collectPromptData', () => {
 
     await expect(collectPromptData(row, mockLogger())).rejects.toThrow(
       'no valid trading routes available',
+    );
+  });
+
+  it('throws when review interval is missing', async () => {
+    const row: ActivePortfolioWorkflow = {
+      id: 'missing-interval',
+      userId: 'user',
+      model: 'model',
+      cashToken: 'USDT',
+      tokens: [{ token: 'BTC', minAllocation: 40 }],
+      risk: 'low',
+      reviewInterval: '  ',
+      agentInstructions: 'inst',
+      aiApiKeyId: null,
+      aiApiKeyEnc: '',
+      manualRebalance: false,
+      useEarn: false,
+      startBalance: null,
+      createdAt: '2025-01-01T00:00:00.000Z',
+      portfolioId: 'missing-interval',
+    };
+
+    await expect(collectPromptData(row, mockLogger())).rejects.toThrow(
+      'workflow review interval is required',
     );
   });
 

--- a/backend/test/indicators.test.ts
+++ b/backend/test/indicators.test.ts
@@ -140,6 +140,18 @@ function calcRsi(closes: number[]) {
   return 100 - 100 / (1 + rs);
 }
 
+function downsampleSeries(series: number[], stride: number) {
+  if (stride <= 1 || series.length === 0) {
+    return series;
+  }
+  const result: number[] = [];
+  const start = (series.length - 1) % stride;
+  for (let idx = start; idx < series.length; idx += stride) {
+    result.push(series[idx]);
+  }
+  return result;
+}
+
 function volumeZ(volumes: number[], lookback: number) {
   const window = Math.min(lookback, volumes.length - 1);
   const slice = volumes.slice(volumes.length - 1 - window, volumes.length - 1);
@@ -500,7 +512,7 @@ describe('fetchMarketOverview', () => {
           volumeStart: 350,
           volumeStep: 1,
         }),
-        '10m': buildKlines(64, {
+        '5m': buildKlines(128, {
           closeStart: 50,
           closeStep: 0.4,
           volumeStart: 500,
@@ -538,7 +550,7 @@ describe('fetchMarketOverview', () => {
           volumeStart: 450,
           volumeStep: 1,
         }),
-        '10m': buildKlines(64, {
+        '5m': buildKlines(128, {
           closeStart: 310,
           closeStep: 0.2,
           volumeStart: 1_500,
@@ -605,7 +617,8 @@ describe('fetchMarketOverview', () => {
     const overview = payload.marketOverview.SOL;
     expect(overview.ltf?.frames).toEqual(['10m', '30m']);
 
-    const closes10 = syntheticIntervals.SOLUSDT['10m'].map((k) => Number(k[4]));
+    const closes5 = syntheticIntervals.SOLUSDT['5m'].map((k) => Number(k[4]));
+    const closes10 = downsampleSeries(closes5, 2);
     const closes30 = syntheticIntervals.SOLUSDT['30m'].map((k) => Number(k[4]));
     const last10 = closes10[closes10.length - 1];
     const last30 = closes30[closes30.length - 1];
@@ -667,7 +680,7 @@ describe('fetchMarketOverview', () => {
           volumeStart: 200,
           volumeStep: 1,
         }),
-        '10m': buildKlines(64, {
+        '5m': buildKlines(128, {
           closeStart: 60,
           closeStep: 0.2,
           volumeStart: 250,
@@ -705,7 +718,7 @@ describe('fetchMarketOverview', () => {
           volumeStart: 300,
           volumeStep: 1,
         }),
-        '10m': buildKlines(64, {
+        '5m': buildKlines(128, {
           closeStart: 305,
           closeStep: 0.1,
           volumeStart: 600,

--- a/backend/test/open-orders-cleanup.test.ts
+++ b/backend/test/open-orders-cleanup.test.ts
@@ -12,9 +12,9 @@ import { setAiKey } from '../src/repos/ai-api-key.js';
 import { reviewWorkflowPortfolio } from '../src/workflows/portfolio-review.js';
 
 const sampleMarketOverview = vi.hoisted(() => ({
-  schema: 'market_overview.v2' as const,
+  schema: 'market_overview.v2.1' as const,
   asOf: '2024-01-01T00:00:00Z',
-  timeframe: { candleInterval: '1h', reviewInterval: '30m', semantics: '' },
+  timeframe: { candleInterval: '1h', decisionInterval: 'PT30M', semantics: '' },
   derivations: {
     trendSlopeRule: '',
     ret1hRule: '',

--- a/backend/test/review-portfolio.test.ts
+++ b/backend/test/review-portfolio.test.ts
@@ -65,11 +65,11 @@ vi.mock('../src/services/sentiment.js', () => ({
 }));
 
 const sampleMarketOverview = vi.hoisted(() => ({
-  schema: 'market_overview.v2' as const,
+  schema: 'market_overview.v2.1' as const,
   asOf: '2024-01-01T00:00:00Z',
   timeframe: {
     candleInterval: '1h',
-    reviewInterval: '30m',
+    decisionInterval: 'PT30M',
     semantics: '',
   },
   derivations: {

--- a/frontend/src/components/PromptVisualizer.tsx
+++ b/frontend/src/components/PromptVisualizer.tsx
@@ -247,7 +247,7 @@ function MarketOverviewSection({
         {marketOverview.timeframe?.candleInterval && (
           <span>
             · {marketOverview.timeframe.candleInterval} candles /
-            {` ${marketOverview.timeframe.reviewInterval ?? 'interval'}`}
+            {` ${marketOverview.timeframe.decisionInterval ?? 'interval'}`}
           </span>
         )}
       </div>

--- a/frontend/src/components/PromptVisualizer.types.ts
+++ b/frontend/src/components/PromptVisualizer.types.ts
@@ -73,7 +73,7 @@ export interface PromptMarketOverview {
   asOf?: string;
   timeframe?: {
     candleInterval?: string;
-    reviewInterval?: string;
+    decisionInterval?: string;
     semantics?: string;
   };
   marketOverview?: Record<string, PromptMarketOverviewAsset>;


### PR DESCRIPTION
## Summary
- require workflows to provide valid decision intervals before prompt assembly and include 1h as a selectable low-timeframe window
- update market overview helpers to build cache keys from explicit cadences, validate timeframe construction, and tolerate 1h-only requests
- cover missing review interval handling and decision interval validation in the indicators and collectPromptData test suites

## Testing
- npm --prefix backend test

------
https://chatgpt.com/codex/tasks/task_e_68e466de8f60832c8c392662ee6ec003