### PR TITLE
Handle price divergence retries in portfolio review

### DIFF
--- a/backend/src/agents/main-trader.ts
+++ b/backend/src/agents/main-trader.ts
@@ -5,6 +5,7 @@ import { isStablecoin } from '../util/tokens.js';
 import {
   fetchMarketOverview,
   createEmptyMarketOverview,
+  clearMarketOverviewCache,
 } from '../services/indicators.js';
 import { fetchFearGreedIndex } from '../services/sentiment.js';
 import {
@@ -248,6 +249,12 @@ async function getNewsContextWithCache(
 export function __resetNewsContextCacheForTest(): void {
   newsContextCache.flushAll();
   pendingNewsContexts.clear();
+}
+
+export function clearMainTraderCaches(): void {
+  newsContextCache.flushAll();
+  pendingNewsContexts.clear();
+  clearMarketOverviewCache();
 }
 
 function createEmptyNewsContext(): NewsContext {

--- a/backend/test/helpers.ts
+++ b/backend/test/helpers.ts
@@ -10,6 +10,7 @@ export function mockLogger(): FastifyBaseLogger {
   const log = {
     info: () => {},
     error: () => {},
+    warn: () => {},
     child: () => log,
   } as unknown as FastifyBaseLogger;
   return log;

--- a/backend/test/open-orders-cleanup.test.ts
+++ b/backend/test/open-orders-cleanup.test.ts
@@ -118,10 +118,16 @@ vi.mock('../src/services/indicators.js', () => ({
   createEmptyMarketOverview: vi
     .fn()
     .mockReturnValue(JSON.parse(JSON.stringify(sampleMarketOverview))),
+  clearMarketOverviewCache: vi.fn(),
 }));
 
 vi.mock('../src/services/rebalance.js', () => ({
-  createDecisionLimitOrders: vi.fn().mockResolvedValue(undefined),
+  createDecisionLimitOrders: vi.fn().mockResolvedValue({
+    placed: 0,
+    canceled: 0,
+    priceDivergenceCancellations: 0,
+    needsPriceDivergenceRetry: false,
+  }),
 }));
 
 describe('cleanup open orders', () => {


### PR DESCRIPTION
## Summary
- introduce a structured retry loop in the portfolio review workflow so price divergence cancels trigger a rerun with cleared caches
- expand `createDecisionLimitOrders` to return detailed counts and a retry flag, and surface a cache clearing helper on the main trader
- update tests and mocks for the richer order results and add coverage for the price divergence retry path

## Testing
- npm --prefix backend test

------
https://chatgpt.com/codex/tasks/task_e_68e520b5cf04832cb524fea1f5dd0500