### PR TITLE
Handle missing orders without crashing

### DIFF
--- a/backend/test/review-portfolio.test.ts
+++ b/backend/test/review-portfolio.test.ts
@@ -253,6 +253,19 @@ describe('reviewPortfolio', () => {
     expect(args.orders).toHaveLength(2);
   });
 
+  it('treats missing orders as a hold decision', async () => {
+    const { workflowId } = await setupWorkflow(['BTC']);
+    const decision = { shortReport: 'holding pattern' } as any;
+    runMainTrader.mockResolvedValue(decision);
+    const log = mockLogger();
+    await reviewWorkflowPortfolio(log, workflowId);
+    expect(createDecisionLimitOrders).not.toHaveBeenCalled();
+    const [result] = await getRecentReviewResults(workflowId, 1);
+    expect(result.rebalance).toBe(false);
+    expect(result.shortReport).toBe('holding pattern');
+    expect(result.error).toBeUndefined();
+  });
+
   it('retries workflow when every order is canceled for price divergence', async () => {
     const { workflowId } = await setupWorkflow(['BTC']);
     const decision = {


### PR DESCRIPTION
## Summary
- normalize AI decisions missing an orders array so we treat them as empty holds instead of crashing
- reuse the normalized decision when validating, persisting results, and placing orders while logging the omission for debugging
- add a regression test proving a missing orders field keeps the workflow healthy and stores the short report

## Testing
- npm --prefix backend test -- review-portfolio.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e5b69331f0832c87ac7e17d24b87d7